### PR TITLE
fix(ordered): module name

### DIFF
--- a/exp/ordered/go.mod
+++ b/exp/ordered/go.mod
@@ -1,4 +1,4 @@
-module github.com/charmbracelet/x/exp/clamp
+module github.com/charmbracelet/x/exp/ordered
 
 go 1.20
 


### PR DESCRIPTION
I know `min`/`max` will be polymorphic in a forthcoming Go … but until then this fixes the implementation here.