### PR TITLE
feat: generic slice 'take' function

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Currently the following packages are available:
 
 * [`higherorder`](./exp/higherorder): generic higher order functions
 * [`ordered`](./exp/ordered): generic `min`, `max`, and `clamp` functions for ordered types
+* [`slice`](./exp/slice): generic slice utilities
 * [`teatest`](./exp/teatest): a library for testing [Bubble Tea](https://github.com/charmbracelet/bubbletea) programs
 
 ## Feedback

--- a/exp/slice/go.mod
+++ b/exp/slice/go.mod
@@ -1,0 +1,3 @@
+module github.com/charmbracelet/x/exp/slice
+
+go 1.20

--- a/exp/slice/slice.go
+++ b/exp/slice/slice.go
@@ -1,0 +1,10 @@
+package slice
+
+// Take returns the first n elements of the given slice. If there are not
+// enough elements in the slice, the whole slice is returned.
+func Take[A any](slice []A, n int) []A {
+	if n > len(slice) {
+		return slice
+	}
+	return slice[:n]
+}

--- a/exp/slice/slice_test.go
+++ b/exp/slice/slice_test.go
@@ -1,0 +1,42 @@
+package slice
+
+import "testing"
+
+func Test_Take(t *testing.T) {
+	for i, tc := range []struct {
+		input    []int
+		take     int
+		expected []int
+	}{
+		{
+			input:    []int{1, 2, 3, 4, 5},
+			take:     3,
+			expected: []int{1, 2, 3},
+		},
+		{
+			input:    []int{1, 2, 3},
+			take:     5,
+			expected: []int{1, 2, 3},
+		},
+		{
+			input:    []int{},
+			take:     2,
+			expected: []int{},
+		},
+		{
+			input:    []int{1, 2, 3},
+			take:     0,
+			expected: []int{},
+		},
+		{
+			input:    nil,
+			take:     2,
+			expected: []int{},
+		},
+	} {
+		actual := Take(tc.input, tc.take)
+		if len(actual) != len(tc.expected) {
+			t.Errorf("Test %d: Expected %v, got %v", i, tc.expected, actual)
+		}
+	}
+}

--- a/go.work
+++ b/go.work
@@ -3,5 +3,6 @@ go 1.20
 use (
 	./exp/higherorder
 	./exp/ordered
-	./exp/teatest/
+	./exp/slice
+	./exp/teatest
 )


### PR DESCRIPTION
`Take` returns a sub-slice containing at most _N_ items from the head of a slice. I know Go’s not tail-call optimized, but I can still see this being handy.