### PR TITLE
feat: add generic reverse and delete functions for slices

### DIFF
--- a/exp/slice/slice.go
+++ b/exp/slice/slice.go
@@ -8,3 +8,25 @@ func Take[A any](slice []A, n int) []A {
 	}
 	return slice[:n]
 }
+
+// Reverse returns a new slice with the elements of the given slice in reverse.
+func Reverse[A any](s []A) []A {
+	r := make([]A, len(s))
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		r[i], r[j] = s[j], s[i]
+	}
+	return r
+}
+
+// Delete returns a new slice with the element at the given index removed.
+// Slice order is preserved. Runs in linear time, aka O(n).
+func Delete[A any](s []A, i int) []A {
+	if i < 0 || i >= len(s) {
+		return s
+	}
+	var d = make([]A, len(s))
+	copy(d, s)
+	copy(d[i:], d[i+1:])  // shift left
+	d[len(d)-1] = *new(A) // zero out last element
+	return s[:len(s)-1]   // truncate
+}

--- a/exp/slice/slice_test.go
+++ b/exp/slice/slice_test.go
@@ -40,3 +40,81 @@ func Test_Take(t *testing.T) {
 		}
 	}
 }
+
+func Test_Reverse(t *testing.T) {
+	for i, tc := range []struct {
+		input    []int
+		expected []int
+	}{
+		{
+			input:    []int{1, 2, 3, 4, 5},
+			expected: []int{5, 4, 3, 2, 1},
+		},
+		{
+			input:    []int{1, 2, 3},
+			expected: []int{3, 2, 1},
+		},
+		{
+			input:    []int{},
+			expected: []int{},
+		},
+		{
+			input:    nil,
+			expected: []int{},
+		},
+	} {
+		actual := Reverse(tc.input)
+		if len(actual) != len(tc.expected) {
+			t.Errorf("Test %d: Expected %v, got %v", i, tc.expected, actual)
+		}
+	}
+}
+
+func Test_Delete(t *testing.T) {
+	for i, tc := range []struct {
+		input    []int
+		index    int
+		expected []int
+	}{
+		{
+			input:    []int{1, 2, 3},
+			index:    1,
+			expected: []int{1, 3},
+		},
+		{
+			input:    []int{1, 2, 3},
+			index:    0,
+			expected: []int{2, 3},
+		},
+		{
+			input:    []int{1, 2, 3},
+			index:    2,
+			expected: []int{1, 2},
+		},
+		{
+			input:    []int{1, 2, 3},
+			index:    4,
+			expected: []int{1, 2, 3},
+		},
+		{
+			input:    []int{1, 2, 3},
+			index:    -1,
+			expected: []int{1, 2, 3},
+		},
+		{
+			input:    []int{},
+			index:    0,
+			expected: []int{},
+		},
+		{
+			input:    nil,
+			index:    0,
+			expected: []int{},
+		},
+	} {
+		actual := Delete(tc.input, tc.index)
+		if len(actual) != len(tc.expected) {
+			t.Errorf("Test %d: Expected %v, got %v", i, tc.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Just a couple o’ funcs I’d love to stop writing over and over.