### PR TITLE
feat: add ordered.First, tests, use stdlib cmp

### DIFF
--- a/exp/ordered/go.mod
+++ b/exp/ordered/go.mod
@@ -1,5 +1,3 @@
 module github.com/charmbracelet/x/exp/ordered
 
 go 1.20
-
-require golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea

--- a/exp/ordered/go.sum
+++ b/exp/ordered/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea h1:vLCWI/yYrdEHyN2JzIzPO3aaQJHQdp89IZBA/+azVC4=
-golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=

--- a/exp/ordered/ordered.go
+++ b/exp/ordered/ordered.go
@@ -1,11 +1,9 @@
 package ordered
 
-import (
-	"golang.org/x/exp/constraints"
-)
+import "cmp"
 
 // Max returns the smaller of a and b.
-func Min[T constraints.Ordered](a, b T) T {
+func Min[T cmp.Ordered](a, b T) T {
 	if a < b {
 		return a
 	}
@@ -13,7 +11,7 @@ func Min[T constraints.Ordered](a, b T) T {
 }
 
 // Max returns the larger of a and b.
-func Max[T constraints.Ordered](a, b T) T {
+func Max[T cmp.Ordered](a, b T) T {
 	if a > b {
 		return a
 	}
@@ -21,9 +19,24 @@ func Max[T constraints.Ordered](a, b T) T {
 }
 
 // Clamp returns a value clamped between the given low and high values.
-func Clamp[T constraints.Ordered](n, low, high T) T {
+func Clamp[T cmp.Ordered](n, low, high T) T {
 	if low > high {
 		low, high = high, low
 	}
 	return Min(high, Max(low, n))
+}
+
+// First returns the first non-default value of a fixed number of
+// arguments of [cmp.Ordered] types.
+func First[T cmp.Ordered](x T, y ...T) T {
+	var empty T
+	if x != empty {
+		return x
+	}
+	for _, s := range y {
+		if s != empty {
+			return s
+		}
+	}
+	return empty
 }

--- a/exp/ordered/ordered_test.go
+++ b/exp/ordered/ordered_test.go
@@ -1,0 +1,171 @@
+package ordered
+
+import (
+	"cmp"
+	"fmt"
+	"testing"
+)
+
+func minName[T cmp.Ordered](x, y, expect T) string {
+	return fmt.Sprintf("min(%v, %v) = %v", x, y, expect)
+}
+
+func assertMin[T cmp.Ordered](tb testing.TB, x, y, expect T) {
+	tb.Helper()
+	if r := Min(x, y); r != expect {
+		tb.Errorf("expected %v, got %v", expect, r)
+	}
+}
+
+func TestMin(t *testing.T) {
+	for expect, args := range map[int][2]int{
+		1:   {1, 2},
+		0:   {1, 0},
+		-10: {1, -10},
+	} {
+		t.Run(minName(args[0], args[1], expect), func(t *testing.T) {
+			assertMin(t, args[0], args[1], expect)
+		})
+	}
+	for expect, args := range map[float64][2]float64{
+		0.1:  {0.1, 2},
+		0.0:  {1, 0},
+		-1.0: {1, -1.0},
+	} {
+		t.Run(minName(args[0], args[1], expect), func(t *testing.T) {
+			assertMin(t, args[0], args[1], expect)
+		})
+	}
+	for expect, args := range map[string][2]string{
+		"":   {"", "a"},
+		"a":  {"aa", "a"},
+		"aa": {"aa", "aaaa"},
+	} {
+		t.Run(minName(args[0], args[1], expect), func(t *testing.T) {
+			assertMin(t, args[0], args[1], expect)
+		})
+	}
+}
+
+func maxName[T cmp.Ordered](x, y, expect T) string {
+	return fmt.Sprintf("max(%v, %v) = %v", x, y, expect)
+}
+
+func assertMax[T cmp.Ordered](tb testing.TB, x, y, expect T) {
+	tb.Helper()
+	if r := Max(x, y); r != expect {
+		tb.Errorf("expected %v, got %v", expect, r)
+	}
+}
+
+func TestMax(t *testing.T) {
+	for expect, args := range map[int][2]int{
+		2: {1, 2},
+		1: {1, 0},
+		0: {0, -10},
+	} {
+		t.Run(maxName(args[0], args[1], expect), func(t *testing.T) {
+			assertMax(t, args[0], args[1], expect)
+		})
+	}
+	for expect, args := range map[float64][2]float64{
+		0.1:  {0.1, 0.02},
+		1.0:  {1, 0},
+		-1.0: {-1.1, -1.0},
+	} {
+		t.Run(maxName(args[0], args[1], expect), func(t *testing.T) {
+			assertMax(t, args[0], args[1], expect)
+		})
+	}
+	for expect, args := range map[string][2]string{
+		"a":    {"", "a"},
+		"aa":   {"aa", "a"},
+		"aaaa": {"aa", "aaaa"},
+	} {
+		t.Run(maxName(args[0], args[1], expect), func(t *testing.T) {
+			assertMax(t, args[0], args[1], expect)
+		})
+	}
+}
+
+func clampName[T cmp.Ordered](n, low, high, expect T) string {
+	return fmt.Sprintf("clamp(%v, %v, %v) = %v", n, low, high, expect)
+}
+
+func assertClamp[T cmp.Ordered](tb testing.TB, n, low, high, expect T) {
+	tb.Helper()
+	if r := Clamp(n, low, high); r != expect {
+		tb.Errorf("expected %v, got %v", expect, r)
+	}
+}
+
+func TestClamp(t *testing.T) {
+	for expect, input := range map[int]struct {
+		n, low, high int
+	}{
+		10: {10, 1, 10},
+		4:  {2, 4, 30},
+		32: {45, 20, 32},
+		15: {15, 33, 11},
+	} {
+		t.Run(clampName(input.n, input.low, input.high, expect), func(t *testing.T) {
+			assertClamp(t, input.n, input.low, input.high, expect)
+		})
+	}
+
+	for expect, input := range map[float64]struct {
+		n, low, high float64
+	}{
+		1.0: {1.0, 1.0, 10.3},
+		0.4: {0.2, 0.4, 30},
+		3.2: {4.5, 2.0, 3.2},
+	} {
+		t.Run(clampName(input.n, input.low, input.high, expect), func(t *testing.T) {
+			assertClamp(t, input.n, input.low, input.high, expect)
+		})
+	}
+
+	for expect, input := range map[string]struct {
+		n, low, high string
+	}{
+		"a":    {"a", "a", "aaaa"},
+		"aaa":  {"aaa", "aa", "aaaa"},
+		"aaaa": {"aaaaaa", "aa", "aaaa"},
+	} {
+		t.Run(clampName(input.n, input.low, input.high, expect), func(t *testing.T) {
+			assertClamp(t, input.n, input.low, input.high, expect)
+		})
+	}
+}
+
+func firstName[T cmp.Ordered](args []T, expect T) string {
+	return fmt.Sprintf("first(%v) = %v", args, expect)
+}
+
+func assertFirst[T cmp.Ordered](tb testing.TB, args []T, expect T) {
+	tb.Helper()
+	if r := First(args[0], args[1:]...); r != expect {
+		tb.Errorf("expected %v, got %v", expect, r)
+	}
+}
+
+func TestFirst(t *testing.T) {
+	for expect, args := range map[string][]string{
+		"a": {"", "", "a", "b", ""},
+		"c": {"c", "", "a", "b", ""},
+	} {
+		t.Run(firstName(args, expect), func(t *testing.T) {
+			assertFirst(t, args, expect)
+		})
+	}
+
+	for expect, args := range map[int][]int{
+		1:   {0, 0, 1, 2},
+		0:   {0, 0},
+		100: {100, 0},
+	} {
+		t.Run(firstName(args, expect), func(t *testing.T) {
+			assertFirst(t, args, expect)
+		})
+	}
+}

--- a/exp/ordered/ordered_test.go
+++ b/exp/ordered/ordered_test.go
@@ -6,25 +6,25 @@ import (
 	"testing"
 )
 
-func minName[T cmp.Ordered](x, y, expect T) string {
-	return fmt.Sprintf("min(%v, %v) = %v", x, y, expect)
-}
-
-func assertMin[T cmp.Ordered](tb testing.TB, x, y, expect T) {
+func assertEqual[T cmp.Ordered](tb testing.TB, result, expect T) {
 	tb.Helper()
-	if r := Min(x, y); r != expect {
-		tb.Errorf("expected %v, got %v", expect, r)
+	if result != expect {
+		tb.Errorf("expected %v, got %v", expect, result)
 	}
 }
 
 func TestMin(t *testing.T) {
+	name := func(x, y, expect any) string {
+		return fmt.Sprintf("min(%v, %v) = %v", x, y, expect)
+	}
+
 	for expect, args := range map[int][2]int{
 		1:   {1, 2},
 		0:   {1, 0},
 		-10: {1, -10},
 	} {
-		t.Run(minName(args[0], args[1], expect), func(t *testing.T) {
-			assertMin(t, args[0], args[1], expect)
+		t.Run(name(args[0], args[1], expect), func(t *testing.T) {
+			assertEqual(t, Min(args[0], args[1]), expect)
 		})
 	}
 	for expect, args := range map[float64][2]float64{
@@ -32,8 +32,8 @@ func TestMin(t *testing.T) {
 		0.0:  {1, 0},
 		-1.0: {1, -1.0},
 	} {
-		t.Run(minName(args[0], args[1], expect), func(t *testing.T) {
-			assertMin(t, args[0], args[1], expect)
+		t.Run(name(args[0], args[1], expect), func(t *testing.T) {
+			assertEqual(t, Min(args[0], args[1]), expect)
 		})
 	}
 	for expect, args := range map[string][2]string{
@@ -41,31 +41,24 @@ func TestMin(t *testing.T) {
 		"a":  {"aa", "a"},
 		"aa": {"aa", "aaaa"},
 	} {
-		t.Run(minName(args[0], args[1], expect), func(t *testing.T) {
-			assertMin(t, args[0], args[1], expect)
+		t.Run(name(args[0], args[1], expect), func(t *testing.T) {
+			assertEqual(t, Min(args[0], args[1]), expect)
 		})
 	}
 }
 
-func maxName[T cmp.Ordered](x, y, expect T) string {
-	return fmt.Sprintf("max(%v, %v) = %v", x, y, expect)
-}
-
-func assertMax[T cmp.Ordered](tb testing.TB, x, y, expect T) {
-	tb.Helper()
-	if r := Max(x, y); r != expect {
-		tb.Errorf("expected %v, got %v", expect, r)
-	}
-}
-
 func TestMax(t *testing.T) {
+	name := func(x, y, expect any) string {
+		return fmt.Sprintf("max(%v, %v) = %v", x, y, expect)
+	}
+
 	for expect, args := range map[int][2]int{
 		2: {1, 2},
 		1: {1, 0},
 		0: {0, -10},
 	} {
-		t.Run(maxName(args[0], args[1], expect), func(t *testing.T) {
-			assertMax(t, args[0], args[1], expect)
+		t.Run(name(args[0], args[1], expect), func(t *testing.T) {
+			assertEqual(t, Max(args[0], args[1]), expect)
 		})
 	}
 	for expect, args := range map[float64][2]float64{
@@ -73,8 +66,8 @@ func TestMax(t *testing.T) {
 		1.0:  {1, 0},
 		-1.0: {-1.1, -1.0},
 	} {
-		t.Run(maxName(args[0], args[1], expect), func(t *testing.T) {
-			assertMax(t, args[0], args[1], expect)
+		t.Run(name(args[0], args[1], expect), func(t *testing.T) {
+			assertEqual(t, Max(args[0], args[1]), expect)
 		})
 	}
 	for expect, args := range map[string][2]string{
@@ -82,24 +75,17 @@ func TestMax(t *testing.T) {
 		"aa":   {"aa", "a"},
 		"aaaa": {"aa", "aaaa"},
 	} {
-		t.Run(maxName(args[0], args[1], expect), func(t *testing.T) {
-			assertMax(t, args[0], args[1], expect)
+		t.Run(name(args[0], args[1], expect), func(t *testing.T) {
+			assertEqual(t, Max(args[0], args[1]), expect)
 		})
 	}
 }
 
-func clampName[T cmp.Ordered](n, low, high, expect T) string {
-	return fmt.Sprintf("clamp(%v, %v, %v) = %v", n, low, high, expect)
-}
-
-func assertClamp[T cmp.Ordered](tb testing.TB, n, low, high, expect T) {
-	tb.Helper()
-	if r := Clamp(n, low, high); r != expect {
-		tb.Errorf("expected %v, got %v", expect, r)
-	}
-}
-
 func TestClamp(t *testing.T) {
+	name := func(n, low, high, expect any) string {
+		return fmt.Sprintf("clamp(%v, %v, %v) = %v", n, low, high, expect)
+	}
+
 	for expect, input := range map[int]struct {
 		n, low, high int
 	}{
@@ -108,8 +94,8 @@ func TestClamp(t *testing.T) {
 		32: {45, 20, 32},
 		15: {15, 33, 11},
 	} {
-		t.Run(clampName(input.n, input.low, input.high, expect), func(t *testing.T) {
-			assertClamp(t, input.n, input.low, input.high, expect)
+		t.Run(name(input.n, input.low, input.high, expect), func(t *testing.T) {
+			assertEqual(t, Clamp(input.n, input.low, input.high), expect)
 		})
 	}
 
@@ -120,8 +106,8 @@ func TestClamp(t *testing.T) {
 		0.4: {0.2, 0.4, 30},
 		3.2: {4.5, 2.0, 3.2},
 	} {
-		t.Run(clampName(input.n, input.low, input.high, expect), func(t *testing.T) {
-			assertClamp(t, input.n, input.low, input.high, expect)
+		t.Run(name(input.n, input.low, input.high, expect), func(t *testing.T) {
+			assertEqual(t, Clamp(input.n, input.low, input.high), expect)
 		})
 	}
 
@@ -132,40 +118,49 @@ func TestClamp(t *testing.T) {
 		"aaa":  {"aaa", "aa", "aaaa"},
 		"aaaa": {"aaaaaa", "aa", "aaaa"},
 	} {
-		t.Run(clampName(input.n, input.low, input.high, expect), func(t *testing.T) {
-			assertClamp(t, input.n, input.low, input.high, expect)
+		t.Run(name(input.n, input.low, input.high, expect), func(t *testing.T) {
+			assertEqual(t, Clamp(input.n, input.low, input.high), expect)
 		})
-	}
-}
-
-func firstName[T cmp.Ordered](args []T, expect T) string {
-	return fmt.Sprintf("first(%v) = %v", args, expect)
-}
-
-func assertFirst[T cmp.Ordered](tb testing.TB, args []T, expect T) {
-	tb.Helper()
-	if r := First(args[0], args[1:]...); r != expect {
-		tb.Errorf("expected %v, got %v", expect, r)
 	}
 }
 
 func TestFirst(t *testing.T) {
-	for expect, args := range map[string][]string{
-		"a": {"", "", "a", "b", ""},
-		"c": {"c", "", "a", "b", ""},
+	name := func(args []any, expect any) string {
+		return fmt.Sprintf("first(%v) = %v", args, expect)
+	}
+	for expect, args := range map[string]struct {
+		x string
+		y []string
+	}{
+		"a": {"", []string{"", "a", "b", ""}},
+		"c": {"c", []string{"", "a", "b", ""}},
+		"":  {"", nil},
 	} {
-		t.Run(firstName(args, expect), func(t *testing.T) {
-			assertFirst(t, args, expect)
+		fnargs := []any{args.x}
+		for _, y := range args.y {
+			fnargs = append(fnargs, y)
+		}
+
+		t.Run(name(fnargs, expect), func(t *testing.T) {
+			assertEqual(t, First(args.x, args.y...), expect)
 		})
 	}
 
-	for expect, args := range map[int][]int{
-		1:   {0, 0, 1, 2},
-		0:   {0, 0},
-		100: {100, 0},
+	for expect, args := range map[int]struct {
+		x int
+		y []int
+	}{
+		1:   {0, []int{0, 1, 2}},
+		0:   {0, []int{0, 0, 0, 0}},
+		100: {100, []int{0}},
 	} {
-		t.Run(firstName(args, expect), func(t *testing.T) {
-			assertFirst(t, args, expect)
+		fnargs := []any{args.x}
+		for _, y := range args.y {
+			fnargs = append(fnargs, y)
+		}
+
+		t.Run(name(fnargs, expect), func(t *testing.T) {
+			assertEqual(t, First(args.x, args.y...), expect)
 		})
 	}
 }


### PR DESCRIPTION
I have written hundreds of `firstNonEmpty` functions over the years, guess this is a good place for it.

Also using stdlib `cmp` instead of `/x/exp/constraints`.

And 100% test coverage :) 