### PR TITLE
made cmp import work correctly

### DIFF
--- a/exp/ordered/ordered.go
+++ b/exp/ordered/ordered.go
@@ -1,6 +1,6 @@
 package ordered
 
-import "cmp"
+import "github.com/google/go-cmp/cmp"
 
 // Max returns the smaller of a and b.
 func Min[T cmp.Ordered](a, b T) T {

--- a/exp/ordered/ordered_test.go
+++ b/exp/ordered/ordered_test.go
@@ -1,7 +1,7 @@
 package ordered
 
 import (
-	"cmp"
+	"github.com/google/go-cmp/cmp"
 	"fmt"
 	"testing"
 )


### PR DESCRIPTION
Was trying to use the new `huh` library but it imports this lib which in turn attempts to import `cmp` but from the GOROOT instead of GOPATH. This fixes that