### PR TITLE
feat: adds getter for program field in TestModel

### DIFF
--- a/exp/teatest/teatest.go
+++ b/exp/teatest/teatest.go
@@ -250,7 +250,7 @@ func (tm *TestModel) Type(s string) {
 	}
 }
 
-// GetProgram gets the TestModel's program
+// GetProgram gets the TestModel's program.
 func (tm *TestModel) GetProgram() *tea.Program {
 	return tm.program
 }

--- a/exp/teatest/teatest.go
+++ b/exp/teatest/teatest.go
@@ -250,6 +250,11 @@ func (tm *TestModel) Type(s string) {
 	}
 }
 
+// GetProgram gets the TestModel's program
+func (tm *TestModel) GetProgram() *tea.Program {
+	return tm.program
+}
+
 // RequireEqualOutput is a helper function to assert the given output is
 // the expected from the golden files, printing its diff in case it is not.
 //


### PR DESCRIPTION
During testing, I need a mechanism to access the `TestModel`'s underlying `program` in order to assign it to a `program` struct that I'm using to send messages back to the TUI during business-logic portions of my app.

In other words, I don't want my test code to have to call `tm.Send`, I'd rather have the existing `Send` calls in my business logic work with the same `program` that the tests are using

Quick and dirty solution is to add a getter for the `program`, but I'm happy to look into other methods.