### PR TITLE
fix(term): ansi: account for some wrap edge cases

### DIFF
--- a/exp/term/ansi/wrap.go
+++ b/exp/term/ansi/wrap.go
@@ -134,9 +134,11 @@ func Wordwrap(s string, limit int, breakpoints string) string {
 	}
 
 	addWord := func() {
-		if curWidth > 0 && word.Len() > 0 {
-			addSpace()
+		if wordLen == 0 {
+			return
 		}
+
+		addSpace()
 		curWidth += wordLen
 		buf.Write(word.Bytes())
 		word.Reset()
@@ -267,13 +269,11 @@ func Wrap(s string, limit int, breakpoints string) string {
 
 	addWord := func() {
 		addBpoint()
-		if curWidth > 0 && word.Len() > 0 {
-			// We use wordLen to determine if we have a word to add
-			// to the buffer. If wordLen is 0, we don't add spaces at the
-			// beginning of a line.
-			addSpace()
+		if word.Len() == 0 {
+			return
 		}
 
+		addSpace()
 		curWidth += wordLen
 		buf.Write(word.Bytes())
 		word.Reset()

--- a/exp/term/ansi/wrap.go
+++ b/exp/term/ansi/wrap.go
@@ -134,7 +134,7 @@ func Wordwrap(s string, limit int, breakpoints string) string {
 	}
 
 	addWord := func() {
-		if wordLen > 0 {
+		if curWidth > 0 {
 			addSpace()
 		}
 		curWidth += wordLen

--- a/exp/term/ansi/wrap.go
+++ b/exp/term/ansi/wrap.go
@@ -349,7 +349,7 @@ func Wrap(s string, limit int, breakpoints string) string {
 				fallthrough
 			case runeContainsAny(r, breakpoints):
 				addSpace()
-				if curWidth+wordLen+1 > limit {
+				if curWidth+wordLen >= limit {
 					// We can't fit the breakpoint in the current line, treat
 					// it as part of the word.
 					word.WriteRune(r)

--- a/exp/term/ansi/wrap.go
+++ b/exp/term/ansi/wrap.go
@@ -267,7 +267,7 @@ func Wrap(s string, limit int, breakpoints string) string {
 
 	addWord := func() {
 		addBpoint()
-		if wordLen > 0 {
+		if curWidth > 0 {
 			// We use wordLen to determine if we have a word to add
 			// to the buffer. If wordLen is 0, we don't add spaces at the
 			// beginning of a line.

--- a/exp/term/ansi/wrap.go
+++ b/exp/term/ansi/wrap.go
@@ -134,7 +134,7 @@ func Wordwrap(s string, limit int, breakpoints string) string {
 	}
 
 	addWord := func() {
-		if curWidth > 0 {
+		if curWidth > 0 && word.Len() > 0 {
 			addSpace()
 		}
 		curWidth += wordLen

--- a/exp/term/ansi/wrap.go
+++ b/exp/term/ansi/wrap.go
@@ -134,7 +134,7 @@ func Wordwrap(s string, limit int, breakpoints string) string {
 	}
 
 	addWord := func() {
-		if wordLen == 0 {
+		if word.Len() == 0 {
 			return
 		}
 
@@ -301,6 +301,11 @@ func Wrap(s string, limit int, breakpoints string) string {
 				if r != utf8.RuneError && unicode.IsSpace(r) {
 					addWord()
 					space.WriteRune(r)
+				} else if bytes.ContainsAny(cluster, breakpoints) {
+					addSpace()
+					addWord()
+					buf.Write(cluster)
+					curWidth++
 				} else {
 					if wordLen+width > limit {
 						// If the word is longer than the limit, we break it

--- a/exp/term/ansi/wrap.go
+++ b/exp/term/ansi/wrap.go
@@ -267,7 +267,7 @@ func Wrap(s string, limit int, breakpoints string) string {
 
 	addWord := func() {
 		addBpoint()
-		if curWidth > 0 {
+		if curWidth > 0 && word.Len() > 0 {
 			// We use wordLen to determine if we have a word to add
 			// to the buffer. If wordLen is 0, we don't add spaces at the
 			// beginning of a line.

--- a/exp/term/ansi/wrap_test.go
+++ b/exp/term/ansi/wrap_test.go
@@ -129,6 +129,12 @@ var wrapCases = []struct {
 		width:    10,
 	},
 	{
+		name:     "long style nbsp",
+		input:    "\x1B[38;2;249;38;114ma really\u00a0long string\x1B[0m",
+		expected: "\x1b[38;2;249;38;114ma\nreally\u00a0lon\ng string\x1b[0m",
+		width:    10,
+	},
+	{
 		name:     "longer",
 		input:    "the quick brown foxxxxxxxxxxxxxxxx jumped over the lazy dog.",
 		expected: "the quick brown\nfoxxxxxxxxxxxxxx\nxx jumped over\nthe lazy dog.",
@@ -143,7 +149,7 @@ var wrapCases = []struct {
 	{
 		name:     "long input",
 		input:    "Rotated keys for a-good-offensive-cheat-code-incorporated/animal-like-law-on-the-rocks.",
-		expected: "Rotated keys for a-good-offensive-cheat-code-incorporated/animal-like-law-on\n-the-rocks.",
+		expected: "Rotated keys for a-good-offensive-cheat-code-incorporated/animal-like-law-\non-the-rocks.",
 		width:    76,
 	},
 	{
@@ -165,16 +171,16 @@ var wrapCases = []struct {
 		width:    3,
 	},
 	{
+		// XXX: Should we preserve spaces on text wrapping?
 		name:     "extra space",
 		input:    "foo ",
 		expected: "foo",
 		width:    3,
 	},
 	{
-		// FIXME: invalid expected
 		name:     "extra space style",
 		input:    "\x1b[mfoo \x1b[m",
-		expected: "\x1b[mfoo \x1b[m",
+		expected: "\x1b[mfoo\n \x1b[m",
 		width:    3,
 	},
 	{
@@ -210,7 +216,7 @@ func TestWrap(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			output := ansi.Wrap(tc.input, tc.width, "")
 			if output != tc.expected {
-				t.Errorf("case %d, expected %q, got %q", i+1, tc.expected, output)
+				t.Errorf("case %d, input %q, expected %q, got %q", i+1, tc.input, tc.expected, output)
 			}
 		})
 	}

--- a/exp/term/ansi/wrap_test.go
+++ b/exp/term/ansi/wrap_test.go
@@ -165,8 +165,14 @@ var wrapCases = []struct {
 		width:    3,
 	},
 	{
-		// TODO: fixme: this is a bug
 		name:     "extra space",
+		input:    "foo ",
+		expected: "foo",
+		width:    3,
+	},
+	{
+		// FIXME: invalid expected
+		name:     "extra space style",
 		input:    "\x1b[mfoo \x1b[m",
 		expected: "\x1b[mfoo \x1b[m",
 		width:    3,

--- a/exp/term/ansi/wrap_test.go
+++ b/exp/term/ansi/wrap_test.go
@@ -165,9 +165,10 @@ var wrapCases = []struct {
 		width:    3,
 	},
 	{
+		// TODO: fixme: this is a bug
 		name:     "extra space",
 		input:    "\x1b[mfoo \x1b[m",
-		expected: "\x1b[mfoo\x1b[m",
+		expected: "\x1b[mfoo \x1b[m",
 		width:    3,
 	},
 	{


### PR DESCRIPTION
Properly count escape codes, better handling of breakpoints, and only break word/breakpoint when necessary.

Fixes: https://github.com/charmbracelet/x/issues/58