### PR TITLE
feat(golden): escapse sequences

### DIFF
--- a/exp/teatest/go.mod
+++ b/exp/teatest/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/charmbracelet/bubbletea v0.26.2
-	github.com/charmbracelet/x/exp/golden v0.0.0-20240222125807-0344fda748f8
+	github.com/charmbracelet/x/exp/golden v0.0.0-20240521172236-71f88323a7ca
 )
 
 require (

--- a/exp/teatest/go.sum
+++ b/exp/teatest/go.sum
@@ -6,6 +6,10 @@ github.com/charmbracelet/bubbletea v0.26.2 h1:Eeb+n75Om9gQ+I6YpbCXQRKHt5Pn4vMwus
 github.com/charmbracelet/bubbletea v0.26.2/go.mod h1:6I0nZ3YHUrQj7YHIHlM8RySX4ZIthTliMY+W8X8b+Gs=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240222125807-0344fda748f8 h1:kyT+aGp1z5jwlus3OY0cP6FuT05jYeeExx/4TYxnyrs=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240222125807-0344fda748f8/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
+github.com/charmbracelet/x/exp/golden v0.0.0-20240521170847-125a30a5d707 h1:dBOaJue+qHEfVuM5mjXmVb11lcqU1ioJNseKi8isdH4=
+github.com/charmbracelet/x/exp/golden v0.0.0-20240521170847-125a30a5d707/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
+github.com/charmbracelet/x/exp/golden v0.0.0-20240521172236-71f88323a7ca h1:Cw9p8EJdhDGIWICF34TIxTcQrAdzBdgkvaLA4AmqDVk=
+github.com/charmbracelet/x/exp/golden v0.0.0-20240521172236-71f88323a7ca/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/exp/teatest/teatest.go
+++ b/exp/teatest/teatest.go
@@ -263,7 +263,7 @@ func (tm *TestModel) GetProgram() *tea.Program {
 // You can update the golden files by running your tests with the -update flag.
 func RequireEqualOutput(tb testing.TB, out []byte) {
 	tb.Helper()
-	golden.RequireEqual(tb, out)
+	golden.RequireEqualEscape(tb, out, true)
 }
 
 func safe(rw io.ReadWriter) io.ReadWriter {


### PR DESCRIPTION
This adds a new `RequireEqualEscape` function that escapes the golden and model outputs to display ansi sequences