### PR TITLE
test cases for truncating strings of equal length to the specificed length

### DIFF
--- a/ansi/truncate_test.go
+++ b/ansi/truncate_test.go
@@ -13,6 +13,9 @@ var tcases = []struct {
 	expect string
 }{
 	{"empty", "", "", 0, ""},
+	{"equalascii", "one", ".", 3, "one"},
+	{"equalemoji", "on👋", ".", 3, "on."},
+	{"equalcontrolemoji", "one\x1b[0m", ".", 3, "one\x1b[0m"},
 	{"simple", "foobar", "", 3, "foo"},
 	{"passthrough", "foobar", "", 10, "foobar"},
 	{"ascii", "hello", "", 3, "hel"},


### PR DESCRIPTION
This PR creates a few unit tests to check situations where the string may be exactly equal length with the trunctation target, as reported in https://github.com/charmbracelet/lipgloss/issues/324

The naive "equalascii" test seems to be relatively straight forward to fixe, but the "equalcontrolemoji" is trickier. The best I can come up with is when the target string length is reached, to scan the rest of the input string to see if the remainder is all control characters or has more printable characters.

While potentially slower, this scan would only need to be done once, at the the point were the truncation would begin, and could be short circuited if any printable characters are found. The slowest case would be when nothing but control characters remain.

I added an `equalemoji` which gets truncated - emojis and chinese characters are treated as double width and therefor truncated, even though they only take up one character space. I'm not sure if that is intentional or not.