### PR TITLE
fix(ansi): truncate: truncate string when input length is equal to output

### DIFF
--- a/ansi/truncate.go
+++ b/ansi/truncate.go
@@ -12,6 +12,10 @@ import (
 // This function is aware of ANSI escape codes and will not break them, and
 // accounts for wide-characters (such as East Asians and emojis).
 func Truncate(s string, length int, tail string) string {
+	if sw := StringWidth(s); sw <= length {
+		return s
+	}
+
 	tw := StringWidth(tail)
 	length -= tw
 	if length < 0 {

--- a/ansi/truncate_test.go
+++ b/ansi/truncate_test.go
@@ -16,6 +16,7 @@ var tcases = []struct {
 	{"equalascii", "one", ".", 3, "one"},
 	{"equalemoji", "on👋", ".", 3, "on."},
 	{"equalcontrolemoji", "one\x1b[0m", ".", 3, "one\x1b[0m"},
+	{"truncate_tail_greater", "foo", "...", 5, "foo"},
 	{"simple", "foobar", "", 3, "foo"},
 	{"passthrough", "foobar", "", 10, "foobar"},
 	{"ascii", "hello", "", 3, "hel"},

--- a/ansi/truncate_test.go
+++ b/ansi/truncate_test.go
@@ -13,6 +13,9 @@ var tcases = []struct {
 	expect string
 }{
 	{"empty", "", "", 0, ""},
+	{"equalascii", "one", ".", 3, "one"},
+	{"equalemoji", "on👋", ".", 3, "on."},
+	{"equalcontrolemoji", "one\x1b[0m", ".", 3, "one\x1b[0m"},
 	{"simple", "foobar", "", 3, "foo"},
 	{"passthrough", "foobar", "", 10, "foobar"},
 	{"ascii", "hello", "", 3, "hel"},
@@ -29,8 +32,8 @@ var tcases = []struct {
 	{"double_width_runes", "你好", "", 2, "你"},
 	{"spaces_only", "    ", "…", 2, " …"},
 	{"longer_tail", "foo", "...", 2, ""},
-	{"same_tail_width", "foo", "...", 3, "..."},
-	{"same_tail_width_control", "\x1b[31mfoo\x1b[0m", "...", 3, "\x1b[31m...\x1b[0m"},
+	{"same_tail_width", "foo", "...", 3, "foo"},
+	{"same_tail_width_control", "\x1b[31mfoo\x1b[0m", "...", 3, "\x1b[31mfoo\x1b[0m"},
 	{"same_width", "foo", "", 3, "foo"},
 	{"truncate_with_tail", "foobar", ".", 4, "foo."},
 	{"style", "I really \x1B[38;2;249;38;114mlove\x1B[0m Go!", "", 8, "I really\x1B[38;2;249;38;114m\x1B[0m"},

--- a/ansi/width.go
+++ b/ansi/width.go
@@ -69,5 +69,31 @@ func StringWidth(s string) int {
 	if s == "" {
 		return 0
 	}
-	return uniseg.StringWidth(Strip(s))
+
+	var (
+		gstate  = -1
+		pstate  = parser.GroundState // initial state
+		cluster string
+		width   int
+	)
+
+	for i := 0; i < len(s); i++ {
+		state, action := parser.Table.Transition(pstate, s[i])
+		switch action {
+		case parser.PrintAction:
+			if utf8ByteLen(s[i]) > 1 {
+				var w int
+				cluster, _, w, gstate = uniseg.FirstGraphemeClusterInString(s[i:], gstate)
+				width += w
+				i += len(cluster) - 1
+				pstate = parser.GroundState
+				continue
+			}
+			width++
+		}
+
+		pstate = state
+	}
+
+	return width
 }


### PR DESCRIPTION

```
goos: darwin
goarch: arm64
pkg: github.com/charmbracelet/x/ansi
                  │   old.txt   │              new.txt               │
                  │   sec/op    │   sec/op     vs base               │
TruncateString-16   24.96n ± 1%   25.83n ± 2%  +3.49% (p=0.001 n=10)

                  │  old.txt   │            new.txt             │
                  │    B/op    │    B/op     vs base            │
TruncateString-16   65.00 ± 0%   65.00 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                  │  old.txt   │            new.txt             │
                  │ allocs/op  │ allocs/op   vs base            │
TruncateString-16   1.000 ± 0%   1.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

Fixes: https://github.com/charmbracelet/lipgloss/issues/324
Fixes: https://github.com/charmbracelet/x/pull/106

CC/ @mikelorant @jbcpollak 