### PR TITLE
fix(ansi): reset uniseq grapheme state after

### DIFF
--- a/ansi/width.go
+++ b/ansi/width.go
@@ -90,6 +90,10 @@ func StringWidth(s string) int {
 				continue
 			}
 			width++
+			fallthrough
+		default:
+			// Reset uniseg state when we're not in a printable state.
+			gstate = -1
 		}
 
 		pstate = state

--- a/ansi/width_test.go
+++ b/ansi/width_test.go
@@ -31,6 +31,7 @@ var cases = []struct {
 	{"unicode", "\x1b[35m“box”\x1b[0m", "“box”", 5},
 	{"just_unicode", "Claire’s Boutique", "Claire’s Boutique", 17},
 	{"unclosed_ansi", "Hey, \x1b[7m\n猴", "Hey, \n猴", 7},
+	{"double_asian_runes", " 你\x1b[8m好.", " 你好.", 6},
 }
 
 func TestStrip(t *testing.T) {


### PR DESCRIPTION
We need to reset the grapheme state after encountering a non-printable character or when we're not using uniseg for string width (ASCII printables have a width of 1 cell).

Fixes: https://github.com/charmbracelet/x/issues/122
Fixes: https://github.com/charmbracelet/x/issues/123
Fixes: https://github.com/charmbracelet/lipgloss/discussions/332