### PR TITLE
Improve ansi.Parser performance and memory allocs

### DIFF
--- a/ansi/parser.go
+++ b/ansi/parser.go
@@ -238,9 +238,7 @@ func (p *Parser) performAction(dispatcher ParserDispatcher, action parser.Action
 			// Collect intermediate bytes
 			// we only store the last intermediate byte
 			p.Cmd &^= 0xff << parser.IntermedShift
-			// p.Cmd[2] &^= 0xff
 			p.Cmd |= int(b) << parser.IntermedShift
-			// p.Cmd[2] |= b
 		}
 
 	case parser.ParamAction:

--- a/ansi/parser.go
+++ b/ansi/parser.go
@@ -2,6 +2,7 @@ package ansi
 
 import (
 	"unicode/utf8"
+	"unsafe"
 
 	"github.com/charmbracelet/x/ansi/parser"
 )
@@ -56,13 +57,13 @@ type Parser struct {
 // If dataSize is zero, the underlying data buffer will be unlimited and will
 // grow as needed.
 func NewParser(paramsSize, dataSize int) *Parser {
-	s := &Parser{
-		Params: make([]int, paramsSize),
-		Data:   make([]byte, dataSize),
-	}
+	s := new(Parser)
 	if dataSize <= 0 {
+		dataSize = 0
 		s.DataLen = -1
 	}
+	s.Params = make([]int, paramsSize)
+	s.Data = make([]byte, dataSize)
 	return s
 }
 
@@ -124,18 +125,19 @@ func (p *Parser) advanceUtf8(dispatcher ParserDispatcher, b byte) parser.Action 
 	}
 
 	if p.ParamsLen < rw {
-		return parser.NoneAction
+		return parser.CollectAction
 	}
 
-	// We have enough bytes to decode the rune
+	// We have enough bytes to decode the rune using unsafe
+	r, _ := utf8.DecodeRune((*[utf8.UTFMax]byte)(unsafe.Pointer(&p.Cmd))[:rw])
 	if dispatcher != nil {
-		dispatcher(Rune(p.Cmd))
+		dispatcher(Rune(r))
 	}
 
 	p.State = parser.GroundState
 	p.ParamsLen = 0
 
-	return parser.NoneAction
+	return parser.PrintAction
 }
 
 func (p *Parser) advance(d ParserDispatcher, b byte, more bool) parser.Action {
@@ -150,14 +152,19 @@ func (p *Parser) advance(d ParserDispatcher, b byte, more bool) parser.Action {
 	if p.State != state {
 		switch p.State {
 		case parser.EscapeState:
-			p.performAction(d, parser.ClearAction, b)
+			p.performAction(d, parser.ClearAction, state, b)
+		}
+		switch state {
+		case parser.Utf8State:
+			// Clear the parser state if we're transitioning to the Utf8State.
+			p.performAction(d, parser.ClearAction, state, b)
 		}
 		if action == parser.PutAction &&
 			p.State == parser.DcsEntryState && state == parser.DcsStringState {
 			// XXX: This is a special case where we need to start collecting
 			// non-string parameterized data i.e. doesn't follow the ECMA-48 §
 			// 5.4.1 string parameters format.
-			p.performAction(d, parser.StartAction, 0)
+			p.performAction(d, parser.StartAction, state, 0)
 		}
 	}
 
@@ -165,34 +172,34 @@ func (p *Parser) advance(d ParserDispatcher, b byte, more bool) parser.Action {
 	switch {
 	case b == ESC && p.State == parser.EscapeState:
 		// Two ESCs in a row
-		p.performAction(d, parser.ExecuteAction, b)
+		p.performAction(d, parser.ExecuteAction, state, b)
 		if !more {
 			// Two ESCs at the end of the buffer
-			p.performAction(d, parser.ExecuteAction, b)
+			p.performAction(d, parser.ExecuteAction, state, b)
 		}
 	case b == ESC && !more:
 		// Last byte is an ESC
-		p.performAction(d, parser.ExecuteAction, b)
+		p.performAction(d, parser.ExecuteAction, state, b)
 	case p.State == parser.EscapeState && b == 'P' && !more:
 		// ESC P (DCS) at the end of the buffer
-		p.performAction(d, parser.DispatchAction, b)
+		p.performAction(d, parser.DispatchAction, state, b)
 	case p.State == parser.EscapeState && b == 'X' && !more:
 		// ESC X (SOS) at the end of the buffer
-		p.performAction(d, parser.DispatchAction, b)
+		p.performAction(d, parser.DispatchAction, state, b)
 	case p.State == parser.EscapeState && b == '[' && !more:
 		// ESC [ (CSI) at the end of the buffer
-		p.performAction(d, parser.DispatchAction, b)
+		p.performAction(d, parser.DispatchAction, state, b)
 	case p.State == parser.EscapeState && b == ']' && !more:
 		// ESC ] (OSC) at the end of the buffer
-		p.performAction(d, parser.DispatchAction, b)
+		p.performAction(d, parser.DispatchAction, state, b)
 	case p.State == parser.EscapeState && b == '^' && !more:
 		// ESC ^ (PM) at the end of the buffer
-		p.performAction(d, parser.DispatchAction, b)
+		p.performAction(d, parser.DispatchAction, state, b)
 	case p.State == parser.EscapeState && b == '_' && !more:
 		// ESC _ (APC) at the end of the buffer
-		p.performAction(d, parser.DispatchAction, b)
+		p.performAction(d, parser.DispatchAction, state, b)
 	default:
-		p.performAction(d, action, b)
+		p.performAction(d, action, state, b)
 	}
 
 	p.State = state
@@ -200,7 +207,7 @@ func (p *Parser) advance(d ParserDispatcher, b byte, more bool) parser.Action {
 	return action
 }
 
-func (p *Parser) performAction(dispatcher ParserDispatcher, action parser.Action, b byte) {
+func (p *Parser) performAction(dispatcher ParserDispatcher, action parser.Action, state parser.State, b byte) {
 	switch action {
 	case parser.IgnoreAction:
 		break
@@ -209,10 +216,7 @@ func (p *Parser) performAction(dispatcher ParserDispatcher, action parser.Action
 		p.clear()
 
 	case parser.PrintAction:
-		if utf8ByteLen(b) > 1 {
-			p.clear()
-			p.collectRune(b)
-		} else if dispatcher != nil {
+		if dispatcher != nil {
 			dispatcher(Rune(b))
 		}
 
@@ -228,10 +232,16 @@ func (p *Parser) performAction(dispatcher ParserDispatcher, action parser.Action
 		p.Cmd |= int(b) << parser.MarkerShift
 
 	case parser.CollectAction:
-		// Collect intermediate bytes
-		// we only store the last intermediate byte
-		p.Cmd &^= 0xff << parser.IntermedShift
-		p.Cmd |= int(b) << parser.IntermedShift
+		if state == parser.Utf8State {
+			p.collectRune(b)
+		} else {
+			// Collect intermediate bytes
+			// we only store the last intermediate byte
+			p.Cmd &^= 0xff << parser.IntermedShift
+			// p.Cmd[2] &^= 0xff
+			p.Cmd |= int(b) << parser.IntermedShift
+			// p.Cmd[2] |= b
+		}
 
 	case parser.ParamAction:
 		// Collect parameters

--- a/ansi/parser.go
+++ b/ansi/parser.go
@@ -155,10 +155,6 @@ func (p *Parser) advance(d ParserDispatcher, b byte, more bool) parser.Action {
 		if p.State == parser.EscapeState {
 			p.performAction(d, parser.ClearAction, state, b)
 		}
-		if state == parser.Utf8State {
-			// Clear the parser state if we're transitioning to the Utf8State.
-			p.performAction(d, parser.ClearAction, state, b)
-		}
 		if action == parser.PutAction &&
 			p.State == parser.DcsEntryState && state == parser.DcsStringState {
 			// XXX: This is a special case where we need to start collecting
@@ -233,6 +229,8 @@ func (p *Parser) performAction(dispatcher ParserDispatcher, action parser.Action
 
 	case parser.CollectAction:
 		if state == parser.Utf8State {
+			// Reset the UTF-8 counter
+			p.ParamsLen = 0
 			p.collectRune(b)
 		} else {
 			// Collect intermediate bytes

--- a/ansi/parser.go
+++ b/ansi/parser.go
@@ -270,8 +270,8 @@ func (p *Parser) performAction(dispatcher ParserDispatcher, action parser.Action
 		}
 
 	case parser.StartAction:
-		if p.DataLen < 0 {
-			p.Data = make([]byte, 0)
+		if p.DataLen < 0 && p.Data != nil {
+			p.Data = p.Data[:0]
 		} else {
 			p.DataLen = 0
 		}

--- a/ansi/parser/transition_table.go
+++ b/ansi/parser/transition_table.go
@@ -107,9 +107,9 @@ func GenerateTransitionTable() TransitionTable {
 		// Anywhere -> OscString
 		table.AddOne(0x9D, state, StartAction, OscStringState)
 		// Anywhere -> Utf8
-		table.AddRange(0xC2, 0xDF, state, PrintAction, Utf8State) // UTF8 2 byte sequence
-		table.AddRange(0xE0, 0xEF, state, PrintAction, Utf8State) // UTF8 3 byte sequence
-		table.AddRange(0xF0, 0xF4, state, PrintAction, Utf8State) // UTF8 4 byte sequence
+		table.AddRange(0xC2, 0xDF, state, CollectAction, Utf8State) // UTF8 2 byte sequence
+		table.AddRange(0xE0, 0xEF, state, CollectAction, Utf8State) // UTF8 3 byte sequence
+		table.AddRange(0xF0, 0xF4, state, CollectAction, Utf8State) // UTF8 4 byte sequence
 	}
 
 	// Ground

--- a/ansi/truncate.go
+++ b/ansi/truncate.go
@@ -26,7 +26,6 @@ func Truncate(s string, length int, tail string) string {
 	var buf bytes.Buffer
 	curWidth := 0
 	ignoring := false
-	gstate := -1
 	pstate := parser.GroundState // initial state
 	b := []byte(s)
 	i := 0
@@ -41,7 +40,7 @@ func Truncate(s string, length int, tail string) string {
 		if state == parser.Utf8State {
 			// This action happens when we transition to the Utf8State.
 			var width int
-			cluster, _, width, gstate = uniseg.FirstGraphemeCluster(b[i:], gstate)
+			cluster, _, width, _ = uniseg.FirstGraphemeCluster(b[i:], -1)
 
 			// increment the index by the length of the cluster
 			i += len(cluster)
@@ -65,7 +64,6 @@ func Truncate(s string, length int, tail string) string {
 			curWidth += width
 			buf.Write(cluster)
 
-			gstate = -1 // reset grapheme state otherwise, width calculation might be off
 			// Done collecting, now we're back in the ground state.
 			pstate = parser.GroundState
 			continue

--- a/ansi/truncate.go
+++ b/ansi/truncate.go
@@ -38,44 +38,41 @@ func Truncate(s string, length int, tail string) string {
 	// collect ANSI escape codes until we reach the end of string.
 	for i < len(b) {
 		state, action := parser.Table.Transition(pstate, b[i])
+		if state == parser.Utf8State {
+			// This action happens when we transition to the Utf8State.
+			var width int
+			cluster, _, width, gstate = uniseg.FirstGraphemeCluster(b[i:], gstate)
 
-		switch action {
-		case parser.PrintAction:
-			if utf8ByteLen(b[i]) > 1 {
-				// This action happens when we transition to the Utf8State.
-				var width int
-				cluster, _, width, gstate = uniseg.FirstGraphemeCluster(b[i:], gstate)
+			// increment the index by the length of the cluster
+			i += len(cluster)
 
-				// increment the index by the length of the cluster
-				i += len(cluster)
-
-				// Are we ignoring? Skip to the next byte
-				if ignoring {
-					continue
-				}
-
-				// Is this gonna be too wide?
-				// If so write the tail and stop collecting.
-				if curWidth+width > length && !ignoring {
-					ignoring = true
-					buf.WriteString(tail)
-				}
-
-				if curWidth+width > length {
-					continue
-				}
-
-				curWidth += width
-				for _, r := range cluster {
-					buf.WriteByte(r)
-				}
-
-				gstate = -1 // reset grapheme state otherwise, width calculation might be off
-				// Done collecting, now we're back in the ground state.
-				pstate = parser.GroundState
+			// Are we ignoring? Skip to the next byte
+			if ignoring {
 				continue
 			}
 
+			// Is this gonna be too wide?
+			// If so write the tail and stop collecting.
+			if curWidth+width > length && !ignoring {
+				ignoring = true
+				buf.WriteString(tail)
+			}
+
+			if curWidth+width > length {
+				continue
+			}
+
+			curWidth += width
+			buf.Write(cluster)
+
+			gstate = -1 // reset grapheme state otherwise, width calculation might be off
+			// Done collecting, now we're back in the ground state.
+			pstate = parser.GroundState
+			continue
+		}
+
+		switch action {
+		case parser.PrintAction:
 			// Is this gonna be too wide?
 			// If so write the tail and stop collecting.
 			if curWidth >= length && !ignoring {

--- a/ansi/width.go
+++ b/ansi/width.go
@@ -68,7 +68,6 @@ func StringWidth(s string) int {
 	}
 
 	var (
-		gstate  = -1
 		pstate  = parser.GroundState // initial state
 		cluster string
 		width   int
@@ -78,7 +77,7 @@ func StringWidth(s string) int {
 		state, action := parser.Table.Transition(pstate, s[i])
 		if state == parser.Utf8State {
 			var w int
-			cluster, _, w, gstate = uniseg.FirstGraphemeClusterInString(s[i:], gstate)
+			cluster, _, w, _ = uniseg.FirstGraphemeClusterInString(s[i:], -1)
 			width += w
 			i += len(cluster) - 1
 			pstate = parser.GroundState
@@ -88,9 +87,6 @@ func StringWidth(s string) int {
 		if action == parser.PrintAction {
 			width++
 		}
-
-		// Reset uniseg state when we're not in a printable state.
-		gstate = -1
 
 		pstate = state
 	}

--- a/ansi/width.go
+++ b/ansi/width.go
@@ -19,13 +19,7 @@ func Strip(s string) string {
 	// This implements a subset of the Parser to only collect runes and
 	// printable characters.
 	for i := 0; i < len(s); i++ {
-		var state, action byte
-		if pstate != parser.Utf8State {
-			state, action = parser.Table.Transition(pstate, s[i])
-		}
-
-		switch {
-		case pstate == parser.Utf8State:
+		if pstate == parser.Utf8State {
 			// During this state, collect rw bytes to form a valid rune in the
 			// buffer. After getting all the rune bytes into the buffer,
 			// transition to GroundState and reset the counters.
@@ -37,16 +31,21 @@ func Strip(s string) string {
 			pstate = parser.GroundState
 			ri = 0
 			rw = 0
-		case action == parser.PrintAction:
-			// This action happens when we transition to the Utf8State.
-			if w := utf8ByteLen(s[i]); w > 1 {
-				rw = w
+			continue
+		}
+
+		state, action := parser.Table.Transition(pstate, s[i])
+		switch action {
+		case parser.CollectAction:
+			if state == parser.Utf8State {
+				// This action happens when we transition to the Utf8State.
+				rw = utf8ByteLen(s[i])
 				buf.WriteByte(s[i])
 				ri++
-				break
 			}
+		case parser.PrintAction:
 			fallthrough
-		case action == parser.ExecuteAction:
+		case parser.ExecuteAction:
 			// collects printable ASCII and non-printable characters
 			buf.WriteByte(s[i])
 		}
@@ -79,16 +78,16 @@ func StringWidth(s string) int {
 
 	for i := 0; i < len(s); i++ {
 		state, action := parser.Table.Transition(pstate, s[i])
+		if state == parser.Utf8State {
+			var w int
+			cluster, _, w, gstate = uniseg.FirstGraphemeClusterInString(s[i:], gstate)
+			width += w
+			i += len(cluster) - 1
+			pstate = parser.GroundState
+			continue
+		}
 		switch action {
 		case parser.PrintAction:
-			if utf8ByteLen(s[i]) > 1 {
-				var w int
-				cluster, _, w, gstate = uniseg.FirstGraphemeClusterInString(s[i:], gstate)
-				width += w
-				i += len(cluster) - 1
-				pstate = parser.GroundState
-				continue
-			}
 			width++
 			fallthrough
 		default:

--- a/ansi/width.go
+++ b/ansi/width.go
@@ -43,9 +43,7 @@ func Strip(s string) string {
 				buf.WriteByte(s[i])
 				ri++
 			}
-		case parser.PrintAction:
-			fallthrough
-		case parser.ExecuteAction:
+		case parser.PrintAction, parser.ExecuteAction:
 			// collects printable ASCII and non-printable characters
 			buf.WriteByte(s[i])
 		}
@@ -86,14 +84,13 @@ func StringWidth(s string) int {
 			pstate = parser.GroundState
 			continue
 		}
-		switch action {
-		case parser.PrintAction:
+
+		if action == parser.PrintAction {
 			width++
-			fallthrough
-		default:
-			// Reset uniseg state when we're not in a printable state.
-			gstate = -1
 		}
+
+		// Reset uniseg state when we're not in a printable state.
+		gstate = -1
 
 		pstate = state
 	}

--- a/ansi/wrap.go
+++ b/ansi/wrap.go
@@ -27,7 +27,6 @@ func Hardwrap(s string, limit int, preserveSpace bool) string {
 		buf          bytes.Buffer
 		curWidth     int
 		forceNewline bool
-		gstate       = -1
 		pstate       = parser.GroundState // initial state
 		b            = []byte(s)
 	)
@@ -42,7 +41,7 @@ func Hardwrap(s string, limit int, preserveSpace bool) string {
 		state, action := parser.Table.Transition(pstate, b[i])
 		if state == parser.Utf8State {
 			var width int
-			cluster, _, width, gstate = uniseg.FirstGraphemeCluster(b[i:], gstate)
+			cluster, _, width, _ = uniseg.FirstGraphemeCluster(b[i:], -1)
 			i += len(cluster)
 
 			if curWidth+width > limit {
@@ -58,7 +57,6 @@ func Hardwrap(s string, limit int, preserveSpace bool) string {
 
 			buf.Write(cluster)
 			curWidth += width
-			gstate = -1 // reset grapheme state otherwise, width calculation might be off
 			pstate = parser.GroundState
 			continue
 		}
@@ -120,7 +118,6 @@ func Wordwrap(s string, limit int, breakpoints string) string {
 		space    bytes.Buffer
 		curWidth int
 		wordLen  int
-		gstate   = -1
 		pstate   = parser.GroundState // initial state
 		b        = []byte(s)
 	)
@@ -154,7 +151,7 @@ func Wordwrap(s string, limit int, breakpoints string) string {
 		state, action := parser.Table.Transition(pstate, b[i])
 		if state == parser.Utf8State {
 			var width int
-			cluster, _, width, gstate = uniseg.FirstGraphemeCluster(b[i:], gstate)
+			cluster, _, width, _ = uniseg.FirstGraphemeCluster(b[i:], -1)
 			i += len(cluster)
 
 			r, _ := utf8.DecodeRune(cluster)
@@ -247,9 +244,8 @@ func Wrap(s string, limit int, breakpoints string) string {
 		buf      bytes.Buffer
 		word     bytes.Buffer
 		space    bytes.Buffer
-		curWidth int // written width of the line
-		wordLen  int // word buffer len without ANSI escape codes
-		gstate   = -1
+		curWidth int                  // written width of the line
+		wordLen  int                  // word buffer len without ANSI escape codes
 		pstate   = parser.GroundState // initial state
 		b        = []byte(s)
 	)
@@ -283,7 +279,7 @@ func Wrap(s string, limit int, breakpoints string) string {
 		state, action := parser.Table.Transition(pstate, b[i])
 		if state == parser.Utf8State {
 			var width int
-			cluster, _, width, gstate = uniseg.FirstGraphemeCluster(b[i:], gstate)
+			cluster, _, width, _ = uniseg.FirstGraphemeCluster(b[i:], -1)
 			i += len(cluster)
 
 			r, _ := utf8.DecodeRune(cluster)

--- a/ansi/wrap.go
+++ b/ansi/wrap.go
@@ -64,9 +64,7 @@ func Hardwrap(s string, limit int, preserveSpace bool) string {
 		}
 
 		switch action {
-		case parser.PrintAction:
-			fallthrough
-		case parser.ExecuteAction:
+		case parser.PrintAction, parser.ExecuteAction:
 			if b[i] == '\n' {
 				addNewline()
 				forceNewline = false
@@ -182,9 +180,7 @@ func Wordwrap(s string, limit int, breakpoints string) string {
 		}
 
 		switch action {
-		case parser.PrintAction:
-			fallthrough
-		case parser.ExecuteAction:
+		case parser.PrintAction, parser.ExecuteAction:
 			r := rune(b[i])
 			switch {
 			case r == '\n':
@@ -324,9 +320,7 @@ func Wrap(s string, limit int, breakpoints string) string {
 		}
 
 		switch action {
-		case parser.PrintAction:
-			fallthrough
-		case parser.ExecuteAction:
+		case parser.PrintAction, parser.ExecuteAction:
 			switch r := rune(b[i]); {
 			case r == '\n':
 				if wordLen == 0 {


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/charmbracelet/x/ansi
                                      │   old.txt   │               new.txt               │
                                      │   sec/op    │   sec/op     vs base                │
Parser/simple-16                        80.91µ ± 1%   80.02µ ± 1%   -1.10% (p=0.035 n=10)
Parser/params-16                        83.31µ ± 0%   82.57µ ± 1%   -0.88% (p=0.035 n=10)
Parser/params_and_data-16               82.45µ ± 0%   83.67µ ± 0%   +1.48% (p=0.000 n=10)
ParserUTF8/simple-16                    77.71µ ± 0%   71.73µ ± 0%   -7.69% (p=0.000 n=10)
ParserUTF8/params-16                    76.61µ ± 0%   71.84µ ± 0%   -6.23% (p=0.000 n=10)
ParserUTF8/params_and_data-16           76.46µ ± 0%   71.68µ ± 0%   -6.26% (p=0.000 n=10)
ParserStateChanges/simple-16            207.5n ± 1%   198.3n ± 0%   -4.41% (p=0.000 n=10)
ParserStateChanges/params-16            222.5n ± 0%   197.8n ± 1%  -11.10% (p=0.000 n=10)
ParserStateChanges/params_and_data-16   207.3n ± 2%   198.5n ± 0%   -4.29% (p=0.000 n=10)
geomean                                 11.03µ        10.53µ        -4.57%

                                      │    old.txt     │                  new.txt                  │
                                      │      B/op      │     B/op      vs base                     │
Parser/simple-16                          0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=10) ¹
Parser/params-16                        4.133Ki ± 0%     0.000Ki ± 0%  -100.00% (p=0.000 n=10)
Parser/params_and_data-16                 0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=10) ¹
ParserUTF8/simple-16                      0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=10) ¹
ParserUTF8/params-16                      0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=10) ¹
ParserUTF8/params_and_data-16             0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=10) ¹
ParserStateChanges/simple-16              0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=10) ¹
ParserStateChanges/params-16              8.000 ± 0%       0.000 ± 0%  -100.00% (p=0.000 n=10)
ParserStateChanges/params_and_data-16     0.000 ± 0%       0.000 ± 0%         ~ (p=1.000 n=10) ¹
geomean                                              ²                 ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                                      │   old.txt    │                 new.txt                 │
                                      │  allocs/op   │ allocs/op   vs base                     │
Parser/simple-16                        0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
Parser/params-16                        121.0 ± 0%       0.0 ± 0%  -100.00% (p=0.000 n=10)
Parser/params_and_data-16               0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
ParserUTF8/simple-16                    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
ParserUTF8/params-16                    0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
ParserUTF8/params_and_data-16           0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
ParserStateChanges/simple-16            0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
ParserStateChanges/params-16            1.000 ± 0%     0.000 ± 0%  -100.00% (p=0.000 n=10)
ParserStateChanges/params_and_data-16   0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=10) ¹
geomean                                            ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

```