### PR TITLE
Introduce ansi.DecodeSequence

### DIFF
--- a/ansi/parser.go
+++ b/ansi/parser.go
@@ -82,6 +82,13 @@ func (p *Parser) clear() {
 	p.Cmd = 0
 }
 
+// clearCmd clears the parser command, params len and data len.
+func (p *Parser) clearCmd() {
+	p.Cmd = 0
+	p.ParamsLen = 0
+	p.DataLen = 0
+}
+
 // StateName returns the name of the current state.
 func (p *Parser) StateName() string {
 	return parser.StateNames[p.State]

--- a/ansi/parser/transition_table.go
+++ b/ansi/parser/transition_table.go
@@ -82,6 +82,7 @@ func r(start, end byte) []byte {
 //     instead use it to denote sub-parameters.
 //   - Support dispatching SosPmApc sequences.
 //   - The DEL (0x7F) character is executed in the Ground state.
+//   - The DEL (0x7F) character is collected in the DcsPassthrough string state.
 //   - The ST C1 control character (0x9C) is executed and not ignored.
 func GenerateTransitionTable() TransitionTable {
 	table := NewTransitionTable(DefaultTableSize)
@@ -212,7 +213,7 @@ func GenerateTransitionTable() TransitionTable {
 	table.AddOne(0x19, DcsStringState, PutAction, DcsStringState)
 	table.AddRange(0x1C, 0x1F, DcsStringState, PutAction, DcsStringState)
 	table.AddRange(0x20, 0x7E, DcsStringState, PutAction, DcsStringState)
-	table.AddOne(0x7F, DcsStringState, IgnoreAction, DcsStringState)
+	table.AddOne(0x7F, DcsStringState, PutAction, DcsStringState)
 	table.AddRange(0x80, 0xFF, DcsStringState, PutAction, DcsStringState) // Allow Utf8 characters by extending the printable range from 0x7F to 0xFF
 	// ST, CAN, SUB, and ESC terminate the sequence
 	table.AddOne(0x1B, DcsStringState, DispatchAction, EscapeState)

--- a/ansi/parser/transition_table.go
+++ b/ansi/parser/transition_table.go
@@ -81,6 +81,7 @@ func r(start, end byte) []byte {
 //   - We don't ignore 0x3A (':') when building Csi and Dcs parameters and
 //     instead use it to denote sub-parameters.
 //   - Support dispatching SosPmApc sequences.
+//   - The DEL (0x7F) character is executed in the Ground state.
 func GenerateTransitionTable() TransitionTable {
 	table := NewTransitionTable(DefaultTableSize)
 	table.SetDefault(NoneAction, GroundState)
@@ -116,7 +117,8 @@ func GenerateTransitionTable() TransitionTable {
 	table.AddRange(0x00, 0x17, GroundState, ExecuteAction, GroundState)
 	table.AddOne(0x19, GroundState, ExecuteAction, GroundState)
 	table.AddRange(0x1C, 0x1F, GroundState, ExecuteAction, GroundState)
-	table.AddRange(0x20, 0x7F, GroundState, PrintAction, GroundState)
+	table.AddRange(0x20, 0x7E, GroundState, PrintAction, GroundState)
+	table.AddOne(0x7F, GroundState, ExecuteAction, GroundState)
 
 	// EscapeIntermediate
 	table.AddRange(0x00, 0x17, EscapeIntermediateState, ExecuteAction, EscapeIntermediateState)

--- a/ansi/parser/transition_table.go
+++ b/ansi/parser/transition_table.go
@@ -82,6 +82,7 @@ func r(start, end byte) []byte {
 //     instead use it to denote sub-parameters.
 //   - Support dispatching SosPmApc sequences.
 //   - The DEL (0x7F) character is executed in the Ground state.
+//   - The ST C1 control character (0x9C) is executed and not ignored.
 func GenerateTransitionTable() TransitionTable {
 	table := NewTransitionTable(DefaultTableSize)
 	table.SetDefault(NoneAction, GroundState)
@@ -92,7 +93,7 @@ func GenerateTransitionTable() TransitionTable {
 		table.AddMany([]byte{0x18, 0x1a, 0x99, 0x9a}, state, ExecuteAction, GroundState)
 		table.AddRange(0x80, 0x8F, state, ExecuteAction, GroundState)
 		table.AddRange(0x90, 0x97, state, ExecuteAction, GroundState)
-		table.AddOne(0x9C, state, IgnoreAction, GroundState)
+		table.AddOne(0x9C, state, ExecuteAction, GroundState)
 		// Anywhere -> Escape
 		table.AddOne(0x1B, state, ClearAction, EscapeState)
 		// Anywhere -> SosStringState

--- a/ansi/parser_decode.go
+++ b/ansi/parser_decode.go
@@ -7,8 +7,32 @@ import (
 
 // DecodeSequence decodes a single ANSI escape sequence or a printable grapheme
 // from the given data. It returns the sequence slice, the number of bytes
-// read, the cell width, and the new state.
-func DecodeSequence[T string | []byte](b T, state byte) (seq T, width int, n int, newState byte) {
+// read, the cell width for each sequence, and the new state.
+//
+// The cell width will always be 0 for control and escape sequences, 1 for
+// ASCII printable characters, and the number of cells other Unicode characters
+// occupy. It uses the uniseg package to calculate the width of Unicode
+// graphemes and characters.
+//
+// Passing a non-nil [*Parser] as the last argument will allow the decoder to
+// collect sequence parameters, data, and commands. The parser cmd will have
+// the packed command value that contains intermediate and marker characters.
+// In the case of a OSC sequence, the cmd will be the OSC command number. Use
+// [Cmd] and [Param] types to unpack command intermediates and markers as well
+// as parameters.
+//
+// Example:
+//
+//	var state byte // the initial state is always zero [parser.GroundState]
+//	p := NewParser(32, 1024) // create a new parser with a 32 params buffer and 1024 data buffer (optional)
+//	input := []byte("\x1b[31mHello, World!\x1b[0m")
+//	for len(input) > 0 {
+//		seq, width, n, newState := DecodeSequence(input, state, p)
+//		log.Printf("seq: %q, width: %d", seq, width)
+//		state = newState
+//		input = input[n:]
+//	}
+func DecodeSequence[T string | []byte](b T, state byte, p *Parser) (seq T, width int, n int, newState byte) {
 	// log.Printf("DecodeSequence(%q, %d)", b, state)
 	// defer func() {
 	// 	log.Printf("DecodeSequence(%q, %d) -> (%q, %d, %d, %d)", b, state, seq, width, n, newState)
@@ -16,21 +40,153 @@ func DecodeSequence[T string | []byte](b T, state byte) (seq T, width int, n int
 	for i := 0; i < len(b); i++ {
 		var action byte
 		newState, action = parser.Table.Transition(state, b[i])
+		if p != nil && state != newState && state == parser.EscapeState {
+			// XXX: We need to clear the cmd when we transition from escape
+			// state to be able to properly collect any intermediate characters
+			// and the command byte in [p].
+			p.Cmd = 0
+		}
 		switch action {
 		case parser.PrintAction:
 			return b[:i+1], 1, i + 1, newState
 		case parser.ExecuteAction:
 			return b[:i+1], 0, i + 1, newState
-		case parser.IgnoreAction:
-			switch b[i] {
-			case DEL:
-				if state == parser.GroundState {
-					// Special case for DEL, which is ignored in the transition table.
+		case parser.DispatchAction:
+			// Increment the last parameter
+			if p != nil && (p.ParamsLen > 0 && p.ParamsLen < len(p.Params)-1 ||
+				p.ParamsLen == 0 && len(p.Params) > 0 && p.Params[0] != parser.MissingParam) {
+				p.ParamsLen++
+			}
+
+			// Handle ST, CAN, SUB, ESC
+			switch {
+			case HasOscPrefix(b):
+				// Handle BEL terminated OSC
+				if b[i] == BEL {
 					return b[:i+1], 0, i + 1, newState
 				}
-			case ST:
-				// Special case for ST, which is ignored in the transition table.
+				fallthrough
+			case HasApcPrefix(b), HasDcsPrefix(b), HasPmPrefix(b), HasSosPrefix(b):
+				if i < len(b) && HasStPrefix(b[i:]) {
+					// Include ST in the sequence
+					if b[i] == ESC {
+						return b[:i+2], 0, i + 2, parser.GroundState
+					}
+					return b[:i+1], 0, i + 1, parser.GroundState
+				}
+				if b[i] == ESC || b[i] == CAN || b[i] == SUB {
+					// Return unterminated sequence
+					return b[:i], 0, i, newState
+				}
 				return b[:i+1], 0, i + 1, newState
+			case HasCsiPrefix(b):
+				if p != nil {
+					p.Cmd |= int(b[i])
+				}
+				return b[:i+1], 0, i + 1, newState
+			case HasEscPrefix(b):
+				if p != nil {
+					p.Cmd |= int(b[i])
+				}
+				// Handle escape sequences
+				return b[:i+1], 0, i + 1, newState
+			}
+		case parser.ClearAction:
+			if p == nil {
+				break
+			}
+			if len(p.Params) > 0 {
+				p.Params[0] = parser.MissingParam
+			}
+			p.Cmd = 0
+			p.ParamsLen = 0
+		case parser.MarkerAction:
+			if p == nil {
+				break
+			}
+			p.Cmd &^= 0xff << parser.MarkerShift
+			p.Cmd |= int(b[i]) << parser.MarkerShift
+		case parser.CollectAction:
+			if p == nil {
+				break
+			}
+			p.Cmd &^= 0xff << parser.IntermedShift
+			p.Cmd |= int(b[i]) << parser.IntermedShift
+		case parser.ParamAction:
+			if p == nil {
+				break
+			}
+
+			if p.ParamsLen >= len(p.Params) {
+				break
+			}
+
+			if b[i] >= '0' && b[i] <= '9' {
+				if p.Params[p.ParamsLen] == parser.MissingParam {
+					p.Params[p.ParamsLen] = 0
+				}
+
+				p.Params[p.ParamsLen] *= 10
+				p.Params[p.ParamsLen] += int(b[i] - '0')
+			}
+
+			if b[i] == ':' {
+				p.Params[p.ParamsLen] |= parser.HasMoreFlag
+			}
+
+			if b[i] == ';' || b[i] == ':' {
+				p.ParamsLen++
+				if p.ParamsLen < len(p.Params) {
+					p.Params[p.ParamsLen] = parser.MissingParam
+				}
+			}
+		case parser.StartAction:
+			if p == nil {
+				break
+			}
+
+			p.DataLen = 0
+			if state >= parser.DcsEntryState && state <= parser.DcsStringState {
+				// Collect the command byte for DCS
+				p.Cmd |= int(b[i])
+			} else {
+				p.Cmd = parser.MissingCommand
+			}
+		case parser.PutAction:
+			if p == nil {
+				break
+			}
+
+			if state == parser.DcsEntryState && newState == parser.DcsStringState {
+				// XXX: This is a special case where we need to start collecting
+				// non-string parameterized data i.e. doesn't follow the ECMA-48 §
+				// 5.4.1 string parameters format.
+				p.Cmd |= int(b[i])
+			}
+
+			if p.DataLen >= len(p.Data) {
+				break
+			}
+
+			p.Data[p.DataLen] = b[i]
+			p.DataLen++
+
+			switch state {
+			case parser.OscStringState:
+				if b[i] == ';' && p.Cmd == parser.MissingCommand {
+					// Try to parse the command
+					for i := 0; i < len(p.Data); i++ {
+						d := p.Data[i]
+						if d < '0' || d > '9' {
+							break
+						}
+						if p.Cmd == parser.MissingCommand {
+							p.Cmd = 0
+						}
+						p.Cmd *= 10
+						p.Cmd += int(d - '0')
+					}
+				}
 			}
 		}
 		if state != newState {
@@ -50,36 +206,6 @@ func DecodeSequence[T string | []byte](b T, state byte) (seq T, width int, n int
 						// Handle unterminated escape sequence
 						return b[:i], 0, i, newState
 					}
-				}
-			}
-			switch action {
-			case parser.DispatchAction:
-				// Handle ST, CAN, SUB, ESC
-				switch {
-				case HasOscPrefix(b):
-					// Handle BEL terminated OSC
-					if b[i] == BEL {
-						return b[:i+1], 0, i + 1, newState
-					}
-					fallthrough
-				case HasApcPrefix(b), HasDcsPrefix(b), HasPmPrefix(b), HasSosPrefix(b):
-					if i < len(b) && HasStPrefix(b[i:]) {
-						// Include ST in the sequence
-						if b[i] == ESC {
-							return b[:i+2], 0, i + 2, parser.GroundState
-						}
-						return b[:i+1], 0, i + 1, parser.GroundState
-					}
-					if b[i] == ESC || b[i] == CAN || b[i] == SUB {
-						// Return unterminated sequence
-						return b[:i], 0, i, newState
-					}
-					return b[:i+1], 0, i + 1, newState
-				case HasCsiPrefix(b):
-					return b[:i+1], 0, i + 1, newState
-				case HasEscPrefix(b):
-					// Handle escape sequences
-					return b[:i+1], 0, i + 1, newState
 				}
 			}
 			state = newState
@@ -148,4 +274,47 @@ func FirstGraphemeCluster[T string | []byte](b T, state int) (T, T, int, int) {
 		return T(cluster), T(rest), width, newState
 	}
 	panic("unreachable")
+}
+
+// Cmd represents a sequence command. This is used to pack/unpack a sequence
+// command with its intermediate and marker characters. Those are commonly
+// found in CSI and DCS sequences.
+type Cmd int
+
+// Marker returns the marker byte of the CSI sequence.
+// This is always gonna be one of the following '<' '=' '>' '?' and in the
+// range of 0x3C-0x3F.
+// Zero is returned if the sequence does not have a marker.
+func (c Cmd) Marker() int {
+	return parser.Marker(int(c))
+}
+
+// Intermediate returns the intermediate byte of the CSI sequence.
+// An intermediate byte is in the range of 0x20-0x2F. This includes these
+// characters from ' ', '!', '"', '#', '$', '%', '&', ”', '(', ')', '*', '+',
+// ',', '-', '.', '/'.
+// Zero is returned if the sequence does not have an intermediate byte.
+func (c Cmd) Intermediate() int {
+	return parser.Intermediate(int(c))
+}
+
+// Command returns the command byte of the CSI sequence.
+func (c Cmd) Command() int {
+	return parser.Command(int(c))
+}
+
+// Param represents a sequence parameter. Sequence parameters with
+// sub-parameters are packed with the HasMoreFlag set. This is used to unpack
+// the parameters from a CSI and DCS sequences.
+type Param int
+
+// Param returns the parameter at the given index.
+// It returns -1 if the parameter does not exist.
+func (s Param) Param() int {
+	return int(s) & parser.ParamMask
+}
+
+// HasMore returns true if the parameter has more sub-parameters.
+func (s Param) HasMore() bool {
+	return int(s)&parser.HasMoreFlag != 0
 }

--- a/ansi/parser_decode.go
+++ b/ansi/parser_decode.go
@@ -1,0 +1,151 @@
+package ansi
+
+import (
+	"github.com/charmbracelet/x/ansi/parser"
+	"github.com/rivo/uniseg"
+)
+
+// DecodeSequence decodes a single ANSI escape sequence or a printable grapheme
+// from the given data. It returns the sequence slice, the number of bytes
+// read, the cell width, and the new state.
+func DecodeSequence[T string | []byte](b T, state byte) (seq T, width int, n int, newState byte) {
+	// log.Printf("DecodeSequence(%q, %d)", b, state)
+	// defer func() {
+	// 	log.Printf("DecodeSequence(%q, %d) -> (%q, %d, %d, %d)", b, state, seq, width, n, newState)
+	// }()
+	for i := 0; i < len(b); i++ {
+		var action byte
+		newState, action = parser.Table.Transition(state, b[i])
+		switch action {
+		case parser.PrintAction:
+			return b[:i+1], 1, i + 1, newState
+		case parser.ExecuteAction:
+			return b[:i+1], 0, i + 1, newState
+		case parser.IgnoreAction:
+			switch b[i] {
+			case DEL:
+				if state == parser.GroundState {
+					// Special case for DEL, which is ignored in the transition table.
+					return b[:i+1], 0, i + 1, newState
+				}
+			case ST:
+				// Special case for ST, which is ignored in the transition table.
+				return b[:i+1], 0, i + 1, newState
+			}
+		}
+		if state != newState {
+			switch newState {
+			case parser.Utf8State:
+				cluster, _, width, _ := FirstGraphemeCluster(b[i:], -1)
+				i += len(cluster)
+				return b[:i], width, i, parser.GroundState
+			case parser.EscapeState:
+				if i < len(b)-1 {
+					switch b[i+1] {
+					case ESC:
+						// Handle double escape
+						return b[:i+1], 0, i + 1, parser.GroundState
+					}
+					if i > 0 && i < len(b) && !HasStPrefix(b[i:]) {
+						// Handle unterminated escape sequence
+						return b[:i], 0, i, newState
+					}
+				}
+			}
+			switch action {
+			case parser.DispatchAction:
+				// Handle ST, CAN, SUB, ESC
+				switch {
+				case HasOscPrefix(b):
+					// Handle BEL terminated OSC
+					if b[i] == BEL {
+						return b[:i+1], 0, i + 1, newState
+					}
+					fallthrough
+				case HasApcPrefix(b), HasDcsPrefix(b), HasPmPrefix(b), HasSosPrefix(b):
+					if i < len(b) && HasStPrefix(b[i:]) {
+						// Include ST in the sequence
+						if b[i] == ESC {
+							return b[:i+2], 0, i + 2, parser.GroundState
+						}
+						return b[:i+1], 0, i + 1, parser.GroundState
+					}
+					if b[i] == ESC || b[i] == CAN || b[i] == SUB {
+						// Return unterminated sequence
+						return b[:i], 0, i, newState
+					}
+					return b[:i+1], 0, i + 1, newState
+				case HasCsiPrefix(b):
+					return b[:i+1], 0, i + 1, newState
+				case HasEscPrefix(b):
+					// Handle escape sequences
+					return b[:i+1], 0, i + 1, newState
+				}
+			}
+			state = newState
+		}
+	}
+	return b, 0, len(b), newState
+}
+
+// HasCsiPrefix returns true if the given byte slice has a CSI prefix.
+func HasCsiPrefix[T string | []byte](b T) bool {
+	return (len(b) > 0 && b[0] == CSI) ||
+		(len(b) > 1 && b[0] == ESC && b[1] == '[')
+}
+
+// HasOscPrefix returns true if the given byte slice has an OSC prefix.
+func HasOscPrefix[T string | []byte](b T) bool {
+	return (len(b) > 0 && b[0] == OSC) ||
+		(len(b) > 1 && b[0] == ESC && b[1] == ']')
+}
+
+// HasApcPrefix returns true if the given byte slice has an APC prefix.
+func HasApcPrefix[T string | []byte](b T) bool {
+	return (len(b) > 0 && b[0] == APC) ||
+		(len(b) > 1 && b[0] == ESC && b[1] == '_')
+}
+
+// HasDcsPrefix returns true if the given byte slice has a DCS prefix.
+func HasDcsPrefix[T string | []byte](b T) bool {
+	return (len(b) > 0 && b[0] == DCS) ||
+		(len(b) > 1 && b[0] == ESC && b[1] == 'P')
+}
+
+// HasSosPrefix returns true if the given byte slice has a SOS prefix.
+func HasSosPrefix[T string | []byte](b T) bool {
+	return (len(b) > 0 && b[0] == SOS) ||
+		(len(b) > 1 && b[0] == ESC && b[1] == 'X')
+}
+
+// HasPmPrefix returns true if the given byte slice has a PM prefix.
+func HasPmPrefix[T string | []byte](b T) bool {
+	return (len(b) > 0 && b[0] == PM) ||
+		(len(b) > 1 && b[0] == ESC && b[1] == '^')
+}
+
+// HasStPrefix returns true if the given byte slice has a ST prefix.
+func HasStPrefix[T string | []byte](b T) bool {
+	return (len(b) > 0 && b[0] == ST) ||
+		(len(b) > 1 && b[0] == ESC && b[1] == '\\')
+}
+
+// HasEscPrefix returns true if the given byte slice has an ESC prefix.
+func HasEscPrefix[T string | []byte](b T) bool {
+	return len(b) > 0 && b[0] == ESC
+}
+
+// FirstGraphemeCluster returns the first grapheme cluster in the given string or byte slice.
+// This is a syntactic sugar function that wraps
+// uniseg.FirstGraphemeClusterInString and uniseg.FirstGraphemeCluster.
+func FirstGraphemeCluster[T string | []byte](b T, state int) (T, T, int, int) {
+	switch b := any(b).(type) {
+	case string:
+		cluster, rest, width, newState := uniseg.FirstGraphemeClusterInString(b, state)
+		return T(cluster), T(rest), width, newState
+	case []byte:
+		cluster, rest, width, newState := uniseg.FirstGraphemeCluster(b, state)
+		return T(cluster), T(rest), width, newState
+	}
+	panic("unreachable")
+}

--- a/ansi/parser_decode_test.go
+++ b/ansi/parser_decode_test.go
@@ -1,0 +1,329 @@
+package ansi
+
+import (
+	"testing"
+)
+
+func TestDecodeSequence(t *testing.T) {
+	type expectedSequence struct {
+		seq   []byte
+		n     int
+		width int
+	}
+	cases := []struct {
+		name     string
+		input    []byte
+		expected []expectedSequence
+	}{
+		{
+			name:     "single byte",
+			input:    []byte{0x1b},
+			expected: []expectedSequence{{seq: []byte{0x1b}, n: 1}},
+		},
+		{
+			name:  "single byte 2",
+			input: []byte{0x00},
+			expected: []expectedSequence{
+				{seq: []byte{0x00}, n: 1},
+			},
+		},
+		{
+			name:  "ascii printable",
+			input: []byte("a"),
+			expected: []expectedSequence{
+				{seq: []byte{'a'}, n: 1, width: 1},
+			},
+		},
+		{
+			name:  "ascii space",
+			input: []byte(" "),
+			expected: []expectedSequence{
+				{seq: []byte{' '}, n: 1, width: 1},
+			},
+		},
+		{
+			name:  "ascii del",
+			input: []byte{DEL},
+			expected: []expectedSequence{
+				{seq: []byte{DEL}, n: 1},
+			},
+		},
+		{
+			name:  "del in the middle of utf8 string",
+			input: []byte{'a', DEL, 'b'},
+			expected: []expectedSequence{
+				{seq: []byte{'a'}, n: 1, width: 1},
+				{seq: []byte{DEL}, n: 1},
+				{seq: []byte{'b'}, n: 1, width: 1},
+			},
+		},
+		{
+			name:  "del in the middle of dcs",
+			input: []byte("\x1bP1;2+xa\x7fb\x1b\\"),
+			expected: []expectedSequence{
+				{seq: []byte("\x1bP1;2+xa\x7fb\x1b\\"), n: 12},
+			},
+		},
+		{
+			name:  "st in the middle of dcs",
+			input: []byte("\x1bP1;2+xa\x9cb\x1b\\"),
+			expected: []expectedSequence{
+				{seq: []byte("\x1bP1;2+xa\x9c"), n: 9},
+				{seq: []byte{'b'}, n: 1, width: 1},
+				{seq: []byte("\x1b\\"), n: 2},
+			},
+		},
+		{
+			name:     "csi",
+			input:    []byte("\x1b[1;2;3m"),
+			expected: []expectedSequence{{seq: []byte("\x1b[1;2;3m"), n: 8}},
+		},
+		{
+			name:  "csi not terminated",
+			input: []byte("\x1b[1;2;3"),
+			expected: []expectedSequence{
+				{seq: []byte("\x1b[1;2;3"), n: 7},
+			},
+		},
+		{
+			name:     "osc",
+			input:    []byte("\x1b]2;charmbracelet: ~/Source/bubbletea\x07"),
+			expected: []expectedSequence{{seq: []byte("\x1b]2;charmbracelet: ~/Source/bubbletea\x07"), n: 38}},
+		},
+		{
+			name:     "osc st terminated",
+			input:    []byte("\x1b]11;ff/00/ff\x1b\\"),
+			expected: []expectedSequence{{seq: []byte("\x1b]11;ff/00/ff\x1b\\"), n: 15}},
+		},
+		{
+			name:     "osc st 8-bit terminated",
+			input:    []byte("\x1b]11;ff/00/ff\x9c\x1baa\x8fa"),
+			expected: []expectedSequence{{seq: []byte("\x1b]11;ff/00/ff\x9c"), n: 14}, {seq: []byte{ESC, 'a'}, n: 2}, {seq: []byte{'a'}, n: 1, width: 1}, {seq: []byte{SS3}, n: 1}, {seq: []byte{'a'}, n: 1, width: 1}},
+		},
+		{
+			name:  "osc followed by esc sequence",
+			input: []byte("\x1b]11;ff/00/ff\x1b[1;2;3m"),
+			expected: []expectedSequence{
+				{seq: []byte("\x1b]11;ff/00/ff"), n: 13},
+				{seq: []byte("\x1b[1;2;3m"), n: 8},
+			},
+		},
+		{
+			name:     "osc esc terminated",
+			input:    []byte("\x1b]11;ff/00/ff\x1b"),
+			expected: []expectedSequence{{seq: []byte("\x1b]11;ff/00/ff"), n: 13}, {seq: []byte{ESC}, n: 1}},
+		},
+		{
+			name:  "multiple sequences",
+			input: []byte("\x1b[1;2;3m\x1b]2;charmbracelet: ~/Source/bubbletea\x07\x1b]11;ff/00/ff\x1b\\"),
+			expected: []expectedSequence{
+				{seq: []byte("\x1b[1;2;3m"), n: 8},
+				{seq: []byte("\x1b]2;charmbracelet: ~/Source/bubbletea\x07"), n: 38},
+				{seq: []byte("\x1b]11;ff/00/ff\x1b\\"), n: 15},
+			},
+		},
+		{
+			name:  "double esc",
+			input: []byte("\x1b\x1b"),
+			expected: []expectedSequence{
+				{seq: []byte{0x1b}, n: 1},
+				{seq: []byte{0x1b}, n: 1},
+			},
+		},
+		{
+			name:  "double st",
+			input: []byte("\x1b\\\x1b\\"),
+			expected: []expectedSequence{
+				{seq: []byte{ESC, '\\'}, n: 2},
+				{seq: []byte{ESC, '\\'}, n: 2},
+			},
+		},
+		{
+			name:  "double st 8-bit",
+			input: []byte("\x9c\x9c"),
+			expected: []expectedSequence{
+				{seq: []byte{ST}, n: 1},
+				{seq: []byte{ST}, n: 1},
+			},
+		},
+		{
+			name:  "ascii printables",
+			input: []byte("Hello, World!"),
+			expected: []expectedSequence{
+				{seq: []byte{'H'}, width: 1, n: 1},
+				{seq: []byte{'e'}, width: 1, n: 1},
+				{seq: []byte{'l'}, width: 1, n: 1},
+				{seq: []byte{'l'}, width: 1, n: 1},
+				{seq: []byte{'o'}, width: 1, n: 1},
+				{seq: []byte{','}, width: 1, n: 1},
+				{seq: []byte{' '}, width: 1, n: 1},
+				{seq: []byte{'W'}, width: 1, n: 1},
+				{seq: []byte{'o'}, width: 1, n: 1},
+				{seq: []byte{'r'}, width: 1, n: 1},
+				{seq: []byte{'l'}, width: 1, n: 1},
+				{seq: []byte{'d'}, width: 1, n: 1},
+				{seq: []byte{'!'}, width: 1, n: 1},
+			},
+		},
+		{
+			name:  "rune",
+			input: []byte("👋"),
+			expected: []expectedSequence{
+				{seq: []byte("👋"), n: 4, width: 2},
+			},
+		},
+		{
+			name:  "multiple sequences with utf8 and double esc",
+			input: []byte("👨🏿‍🌾\x1b\x1b \x1b[?1:2:3mÄabc\x1b\x1bP+q\x1b\\"),
+			expected: []expectedSequence{
+				{seq: []byte("👨🏿‍🌾"), n: 15, width: 2},
+				{seq: []byte{ESC}, n: 1},
+				{seq: []byte{ESC, ' '}, n: 2},
+				{seq: []byte("\x1b[?1:2:3m"), n: 9},
+				{seq: []byte("Ä"), n: 2, width: 1},
+				{seq: []byte{'a'}, n: 1, width: 1},
+				{seq: []byte{'b'}, n: 1, width: 1},
+				{seq: []byte{'c'}, n: 1, width: 1},
+				{seq: []byte{ESC}, n: 1},
+				{seq: []byte("\x1bP+q\x1b\\"), n: 6},
+			},
+		},
+		{
+			name:  "style sequences",
+			input: []byte("hello, \x1b[1;2;3mworld\x1b[0m!"),
+			expected: []expectedSequence{
+				{seq: []byte("h"), n: 1, width: 1},
+				{seq: []byte("e"), n: 1, width: 1},
+				{seq: []byte("l"), n: 1, width: 1},
+				{seq: []byte("l"), n: 1, width: 1},
+				{seq: []byte("o"), n: 1, width: 1},
+				{seq: []byte(","), n: 1, width: 1},
+				{seq: []byte(" "), n: 1, width: 1},
+				{seq: []byte("\x1b[1;2;3m"), n: 8},
+				{seq: []byte("w"), n: 1, width: 1},
+				{seq: []byte("o"), n: 1, width: 1},
+				{seq: []byte("r"), n: 1, width: 1},
+				{seq: []byte("l"), n: 1, width: 1},
+				{seq: []byte("d"), n: 1, width: 1},
+				{seq: []byte("\x1b[0m"), n: 4},
+				{seq: []byte("!"), n: 1, width: 1},
+			},
+		},
+		{
+			name:  "osc with c1",
+			input: []byte("\x1b]11;\x90?\x1b\\"),
+			expected: []expectedSequence{
+				{seq: []byte("\x1b]11;\x90?\x1b\\"), n: 9},
+			},
+		},
+		{
+			name:  "unterminated csi with escape sequence",
+			input: []byte("\x1b[1;2;3\x1bOa"),
+			expected: []expectedSequence{
+				{seq: []byte("\x1b[1;2;3"), n: 7},
+				{seq: []byte("\x1bO"), n: 2},
+				{seq: []byte{'a'}, n: 1, width: 1},
+			},
+		},
+		{
+			name:  "ss3",
+			input: []byte("\x1bOa"),
+			expected: []expectedSequence{
+				{seq: []byte("\x1bO"), n: 2},
+				{seq: []byte{'a'}, n: 1, width: 1},
+			},
+		},
+		{
+			name:  "ss3 8-bit",
+			input: []byte("\x8fa"),
+			expected: []expectedSequence{
+				{seq: []byte{SS3}, n: 1},
+				{seq: []byte{'a'}, n: 1, width: 1},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var state byte
+			input := tc.input
+			results := make([]expectedSequence, 0)
+			for len(input) > 0 {
+				seq, width, n, newState := DecodeSequence(input, state)
+				state = newState
+				input = input[n:]
+				results = append(results, expectedSequence{seq: seq, width: width, n: n})
+			}
+			if len(results) != len(tc.expected) {
+				t.Fatalf("expected %d sequences, got %d\n\n%#v\n\n%#v", len(tc.expected), len(results), tc.expected, results)
+			}
+			for i, r := range results {
+				if r.n != tc.expected[i].n {
+					t.Errorf("expected %d bytes, got %d", tc.expected[i].n, r.n)
+				}
+				if r.width != tc.expected[i].width {
+					t.Errorf("expected %d width, got %d", tc.expected[i].width, r.width)
+				}
+				if string(r.seq) != string(tc.expected[i].seq) {
+					t.Errorf("expected %q, got %q", string(tc.expected[i].seq), string(r.seq))
+				}
+
+			}
+		})
+	}
+}
+
+func FuzzDecodeSequence(f *testing.F) {
+	var b byte
+	for b < 0x80 {
+		f.Add([]byte{b})
+		b++
+	}
+
+	f.Add([]byte("\x1b"))
+	f.Add([]byte("\x1b[1;2;3m"))
+	f.Add([]byte("\x1b]2;charmbracelet: ~/Source/bubbletea\x07"))
+	f.Add([]byte("\x1b]11;ff/00/ff\x1b\\"))
+	f.Add([]byte("\x1b]11;ff/00/ff\x9c\x1baa\x8fa"))
+	f.Add([]byte("\x1b]11;ff/00/ff\x1b[1;2;3m"))
+	f.Add([]byte("\x1b]11;ff/00/ff\x1b"))
+	f.Add([]byte("\x1b[1;2;3m\x1b]2;charmbracelet: ~/Source/bubbletea\x07\x1b]11;ff/00/ff\x1b\\"))
+	f.Add([]byte("Hello, World!"))
+	f.Add([]byte("👋a"))
+	f.Add([]byte("👨🏿‍🌾"))
+	f.Fuzz(func(t *testing.T, b []byte) {
+		var state byte
+		var n int
+		for len(b) > 0 {
+			_, _, n, state = DecodeSequence(b, state)
+			if n == 0 {
+				break
+			}
+			b = b[n:]
+		}
+	})
+}
+
+func BenchmarkDecodeSequence(b *testing.B) {
+	var state byte
+	var n int
+	input := []byte("\x1b[1;2;3màbc\x90?123;456+q\x9c\x7f ")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		in := input
+		for len(in) > 0 {
+			_, _, n, state = DecodeSequence(in, state)
+			in = in[n:]
+		}
+	}
+}
+
+func BenchmarkDecodeParser(b *testing.B) {
+	p := NewParser(32, 1024)
+	input := []byte("\x1b[1;2;3màbc\x90?123;456+q\x9c\x7f ")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		p.Parse(func(s Sequence) {
+		}, input)
+	}
+}

--- a/ansi/parser_decode_test.go
+++ b/ansi/parser_decode_test.go
@@ -270,6 +270,15 @@ func TestDecodeSequence(t *testing.T) {
 			},
 		},
 		{
+			name:  "ESC followed by C0",
+			input: []byte("\x1b[\x00a"),
+			expected: []expectedSequence{
+				{seq: []byte("\x1b["), n: 2},
+				{seq: []byte{0x00}, n: 1},
+				{seq: []byte{'a'}, n: 1, width: 1},
+			},
+		},
+		{
 			name:  "unterminated DCS sequence",
 			input: []byte("\x1bP1;2+xa"),
 			expected: []expectedSequence{

--- a/ansi/parser_decode_test.go
+++ b/ansi/parser_decode_test.go
@@ -280,9 +280,30 @@ func TestDecodeSequence(t *testing.T) {
 			name:  "invalid DCS sequence",
 			input: []byte("\x1bP\x1b\\ab"),
 			expected: []expectedSequence{
-				{seq: []byte("\x1bP\x1b\\"), n: 4, cmd: ESC, data: []byte{ESC, '\\'}},
+				{seq: []byte("\x1bP\x1b\\"), n: 4},
 				{seq: []byte{'a'}, n: 1, width: 1},
 				{seq: []byte{'b'}, n: 1, width: 1},
+			},
+		},
+		{
+			name:  "special Tmux DCS passthrough sequence",
+			input: []byte("\x1bPtmux;abc\x1b\\"),
+			expected: []expectedSequence{
+				{seq: []byte("\x1bPtmux;abc\x1b\\"), n: 12, cmd: 't', data: []byte("mux;abc")},
+			},
+		},
+		{
+			name:  "special Tmux DCS passthrough sequence with OSC sequence",
+			input: []byte("\x1bPtmux;\x1b\x1b]2;charmbracelet: ~/Source/bubbletea\x07\x1b\\"),
+			expected: []expectedSequence{
+				{seq: []byte("\x1bPtmux;\x1b\x1b]2;charmbracelet: ~/Source/bubbletea\x07\x1b\\"), n: 48, cmd: 't', data: []byte("mux;\x1b\x1b]2;charmbracelet: ~/Source/bubbletea\x07")},
+			},
+		},
+		{
+			name:  "GNU Screen DCS passthrough",
+			input: []byte("\x1bP\x1b]2;charmbracelet: ~/Source/bubbletea\x07\x1b\\"),
+			expected: []expectedSequence{
+				{seq: []byte("\x1bP\x1b]2;charmbracelet: ~/Source/bubbletea\x07\x1b\\"), n: 42, cmd: ESC, data: []byte("\x1b]2;charmbracelet: ~/Source/bubbletea\x07")},
 			},
 		},
 	}

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,0 +1,29 @@
+module examples
+
+go 1.18
+
+require (
+	github.com/charmbracelet/x/ansi v0.1.4
+	github.com/charmbracelet/x/exp/term v0.0.0-20240515162549-69ee4f765313
+	github.com/charmbracelet/x/input v0.1.3
+	github.com/charmbracelet/x/term v0.1.1
+	github.com/rivo/uniseg v0.4.7
+)
+
+require (
+	github.com/charmbracelet/x/windows v0.1.2 // indirect
+	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	golang.org/x/sys v0.22.0 // indirect
+)
+
+replace github.com/charmbracelet/x/ansi => ../ansi
+
+replace github.com/charmbracelet/x/term => ../term
+
+replace github.com/charmbracelet/x/input => ../input
+
+replace github.com/charmbracelet/x/windows => ../windows
+
+replace github.com/charmbracelet/x/exp => ../exp

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,0 +1,14 @@
+github.com/charmbracelet/x/exp/term v0.0.0-20240515162549-69ee4f765313 h1:fAAMnqSGV4lwoXfS8ZB7MaLvXayMAAVifUx9sOFRyOo=
+github.com/charmbracelet/x/exp/term v0.0.0-20240515162549-69ee4f765313/go.mod h1:YBotIGhfoWhHDlnUpJMkjebGV2pdGRCn1Y4/Nk/vVcU=
+github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
+github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
+github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
+github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/examples/parserlog/main.go
+++ b/examples/parserlog/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/ansi/parser"
+)
+
+func main() {
+	bts, err := io.ReadAll(os.Stdin)
+	if err != nil && err != io.EOF {
+		log.Fatal(err)
+	}
+
+	var str string
+	parser := ansi.NewParser(parser.MaxParamsSize, 0)
+	dispatcher := func(s ansi.Sequence) {
+		if _, ok := s.(ansi.Rune); !ok && str != "" {
+			fmt.Printf("[Print] %s\n", str)
+			str = ""
+		}
+		switch s := s.(type) {
+		case ansi.Rune:
+			str += string(s)
+		case ansi.ControlCode:
+			fmt.Printf("[ControlCode] %q\n", s)
+		case ansi.EscSequence:
+			fmt.Print("[EscSequence] ")
+			fmt.Printf("Cmd=%c ", s.Command())
+			if intermed := s.Intermediate(); intermed != 0 {
+				fmt.Printf("Inter=%c", intermed)
+			}
+			fmt.Println()
+		case ansi.CsiSequence:
+			fmt.Print("[CsiSequence] ")
+			fmt.Printf("Cmd=%q ", s.Command())
+			if marker := s.Marker(); marker != 0 {
+				fmt.Printf("Marker=%q, ", marker)
+			}
+			if intermed := s.Intermediate(); intermed != 0 {
+				fmt.Printf("Intermed=%q, ", intermed)
+			}
+			for i := 0; i < s.Len(); i++ {
+				if i == 0 {
+					fmt.Printf("Params=[")
+				}
+				fmt.Printf("%+v", s.Subparams(i))
+				if i != s.Len()-1 {
+					fmt.Print(", ")
+				}
+				if i == s.Len()-1 {
+					fmt.Print("]")
+				}
+			}
+			fmt.Println()
+		case ansi.OscSequence:
+			fmt.Print("[OscSequence] ")
+			fmt.Printf("Cmd=%d ", s.Command())
+			fmt.Printf("Params=%+v\n", s.Params())
+		case ansi.DcsSequence:
+			fmt.Print("[DcsSequence] ")
+			fmt.Printf("Cmd=%q ", s.Command())
+			if marker := s.Marker(); marker != 0 {
+				fmt.Printf("Marker=%q, ", marker)
+			}
+			if intermed := s.Intermediate(); intermed != 0 {
+				fmt.Printf("Intermed=%q, ", intermed)
+			}
+			for i := 0; i < s.Len(); i++ {
+				if i == 0 {
+					fmt.Printf("Params=[")
+				}
+				fmt.Printf("%+v", s.Subparams(i))
+				if i != s.Len()-1 {
+					fmt.Print(", ")
+				}
+				if i == s.Len()-1 {
+					fmt.Print("] ")
+				}
+			}
+			fmt.Printf("Data=%q\n", s.Data)
+		case ansi.SosSequence:
+			fmt.Printf("[SosSequence] Data=%q\n", s.Data)
+		case ansi.PmSequence:
+			fmt.Printf("[PmSequence] Data=%q\n", s.Data)
+		case ansi.ApcSequence:
+			fmt.Printf("[ApcSequence] Data=%q\n", s.Data)
+		}
+	}
+
+	parser.Parse(dispatcher, bts)
+	if str != "" {
+		fmt.Printf("[Print] %s\n", str)
+	}
+}

--- a/examples/parserlog2/main.go
+++ b/examples/parserlog2/main.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/ansi/parser"
+)
+
+func main() {
+	input, err := io.ReadAll(os.Stdin)
+	if err != nil && err != io.EOF {
+		log.Fatal(err)
+	}
+
+	var state byte
+	p := ansi.NewParser(32, 1024)
+	for len(input) > 0 {
+		seq, width, n, newState := ansi.DecodeSequence(input, state, p)
+		switch {
+		case ansi.HasOscPrefix(seq):
+			fmt.Printf("OSC sequence: %q, cmd: %d, data: %q", seq, p.Cmd, p.Data[:p.DataLen])
+			fmt.Println()
+		case ansi.HasDcsPrefix(seq):
+			c := ansi.Cmd(p.Cmd)
+			intermed, marker, cmd := c.Intermediate(), c.Marker(), c.Command()
+			fmt.Printf("DCS sequence: %q,", seq)
+			if intermed != 0 {
+				fmt.Printf(" intermed: %q,", intermed)
+			}
+			if marker != 0 {
+				fmt.Printf(" marker: %q,", marker)
+			}
+			if cmd != 0 {
+				fmt.Printf(" cmd: %q,", cmd)
+			}
+			fmt.Print(" params: [")
+			var more bool
+			for i := 0; i < p.ParamsLen; i++ {
+				r := ansi.Param(p.Params[i])
+				param, hasMore := r.Param(), r.HasMore()
+				if more != hasMore {
+					fmt.Print("[")
+				}
+				if param == parser.MissingParam {
+					fmt.Print("MISSING")
+				} else {
+					fmt.Printf("%d", param)
+				}
+				if i != p.ParamsLen-1 {
+					fmt.Print(", ")
+				}
+				if more != hasMore {
+					fmt.Print("]")
+				}
+				more = hasMore
+			}
+			fmt.Printf("], data: %q", p.Data[:p.DataLen])
+			fmt.Println()
+
+		case ansi.HasSosPrefix(seq):
+			fmt.Printf("SOS sequence: %q, data: %q", seq, p.Data[:p.DataLen])
+			fmt.Println()
+		case ansi.HasPmPrefix(seq):
+			fmt.Printf("PM sequence: %q, data: %q", seq, p.Data[:p.DataLen])
+			fmt.Println()
+		case ansi.HasApcPrefix(seq):
+			fmt.Printf("APC sequence: %q, data: %q", seq, p.Data[:p.DataLen])
+			fmt.Println()
+		case ansi.HasCsiPrefix(seq):
+			c := ansi.Cmd(p.Cmd)
+			intermed, marker, cmd := c.Intermediate(), c.Marker(), c.Command()
+			fmt.Printf("CSI sequence: %q,", seq)
+			if intermed != 0 {
+				fmt.Printf(" intermed: %q,", intermed)
+			}
+			if marker != 0 {
+				fmt.Printf(" marker: %q,", marker)
+			}
+			if cmd != 0 {
+				fmt.Printf(" cmd: %q,", cmd)
+			}
+			fmt.Print(" params: [")
+			var more bool
+			for i := 0; i < p.ParamsLen; i++ {
+				r := ansi.Param(p.Params[i])
+				param, hasMore := r.Param(), r.HasMore()
+				if hasMore && more != hasMore {
+					fmt.Print("[")
+				}
+				if param == parser.MissingParam {
+					fmt.Print("MISSING")
+				} else {
+					fmt.Printf("%d", param)
+				}
+				if !hasMore && more != hasMore {
+					fmt.Print("]")
+				}
+				if i != p.ParamsLen-1 {
+					fmt.Print(", ")
+				}
+				more = hasMore
+			}
+			fmt.Print("]")
+			fmt.Println()
+
+		case ansi.HasEscPrefix(seq):
+			if !bytes.Equal(seq, []byte{ansi.ESC}) {
+				c := ansi.Cmd(p.Cmd)
+				intermed, cmd := c.Intermediate(), c.Command()
+				fmt.Printf("ESC sequence: %q", seq)
+				if intermed != 0 {
+					fmt.Printf(", intermed: %q", intermed)
+				}
+				if cmd != 0 {
+					fmt.Printf(", cmd: %q", cmd)
+				}
+				fmt.Println()
+				break
+			}
+			fallthrough
+		default:
+			if width > 0 {
+				fmt.Printf("Print: %s, width: %d", seq, width)
+			} else {
+				fmt.Printf("Execute: %q", seq)
+			}
+			fmt.Println()
+		}
+		state = newState
+		input = input[n:]
+	}
+}

--- a/go.work
+++ b/go.work
@@ -6,6 +6,7 @@ use (
 	./conpty
 	./editor
 	./errors
+	./examples
 	./exp/golden
 	./exp/higherorder
 	./exp/maps


### PR DESCRIPTION
This new `ansi.DecodeSequence` replaces the existing ANSI parser by providing a simpler, static method of decoding a single sequence. Instead of passing a `ansi.ParserDispatcher` func, use `ansi.DecodeSequence` to segment the given input into sequences without allocating any memory. This also adds support to sequence widths by using the uniseg library to decode graphemes and report sequence widths instead of manually using uniseg in the dispatcher func in the parser.

See [parserlog2/main.go](https://github.com/charmbracelet/x/blob/ansi/decode-seq/examples/parserlog2/main.go) for an example of how this works compared to [parserlog/main.go](https://github.com/charmbracelet/x/blob/ansi/decode-seq/examples/parserlog/main.go)

some benchmarks:
```
goos: darwin
goarch: arm64
pkg: github.com/charmbracelet/x/ansi
BenchmarkDecodeSequence-16       8324944               138.2 ns/op             0 B/op          0 allocs/op
BenchmarkDecodeParser-16         6610164               181.8 ns/op            96 B/op          2 allocs/op
PASS
ok      github.com/charmbracelet/x/ansi 2.857s
?       github.com/charmbracelet/x/ansi/parser  [no test files]
```