### PR TITLE
feat(ansi): add mode 2027

### DIFF
--- a/ansi/mode.go
+++ b/ansi/mode.go
@@ -130,6 +130,18 @@ const (
 	RequestSyncdOutput = "\x1b[?2026$p"
 )
 
+// Grapheme Clustering Mode is a mode that determines whether the terminal
+// should look for grapheme clusters instead of single runes in the rendered
+// text. This makes the terminal properly render combining characters such as
+// emojis.
+//
+// See: https://github.com/contour-terminal/terminal-unicode-core
+const (
+	EnableGraphemeClustering  = "\x1b[?2027h"
+	DisableGraphemeClustering = "\x1b[?2027l"
+	RequestGraphemeClustering = "\x1b[?2027$p"
+)
+
 // Win32Input is a mode that determines whether input is processed by the
 // Win32 console and Conpty.
 //

--- a/ansi/parser_decode.go
+++ b/ansi/parser_decode.go
@@ -30,7 +30,8 @@ const (
 // The cell width will always be 0 for control and escape sequences, 1 for
 // ASCII printable characters, and the number of cells other Unicode characters
 // occupy. It uses the uniseg package to calculate the width of Unicode
-// graphemes and characters.
+// graphemes and characters. This means it will always do grapheme clustering
+// (mode 2027).
 //
 // Passing a non-nil [*Parser] as the last argument will allow the decoder to
 // collect sequence parameters, data, and commands. The parser cmd will have


### PR DESCRIPTION
This adds the necessary sequences to enable/disable/request mode 2027 (grapheme clustering).

See https://mitchellh.com/writing/grapheme-clusters-in-terminals See https://github.com/contour-terminal/terminal-unicode-core