### PR TITLE
refactor(colors): update to lipgloss alpha

### DIFF
--- a/colors/colors.go
+++ b/colors/colors.go
@@ -3,33 +3,85 @@ package colors
 import "github.com/charmbracelet/lipgloss"
 
 var (
-	WhiteBright = lipgloss.AdaptiveColor{Light: "#FFFDF5", Dark: "#FFFDF5"}
+	Light = Colors{
+		WhiteBright:     lipgloss.Color("#FFFDF5"),
+		Normal:          lipgloss.Color("#1A1A1A"),
+		NormalDim:       lipgloss.Color("#A49FA5"),
+		Gray:            lipgloss.Color("#909090"),
+		GrayMid:         lipgloss.Color("#B2B2B2"),
+		GrayDark:        lipgloss.Color("#DDDADA"),
+		GrayBright:      lipgloss.Color("#847A85"),
+		GrayBrightDim:   lipgloss.Color("#C2B8C2"),
+		Indigo:          lipgloss.Color("#5A56E0"),
+		IndigoDim:       lipgloss.Color("#9498FF"),
+		IndigoSubtle:    lipgloss.Color("#7D79F6"),
+		IndigoSubtleDim: lipgloss.Color("#BBBDFF"),
+		YellowGreen:     lipgloss.Color("#04B575"),
+		YellowGreenDull: lipgloss.Color("#6BCB94"),
+		Fuschia:         lipgloss.Color("#EE6FF8"),
+		FuchsiaDim:      lipgloss.Color("#F1A8FF"),
+		FuchsiaDull:     lipgloss.Color("#AD58B4"),
+		FuchsiaDullDim:  lipgloss.Color("#F6C9FF"),
+		Green:           lipgloss.Color("#04B575"),
+		GreenDim:        lipgloss.Color("#72D2B0"),
+		Red:             lipgloss.Color("#FF4672"),
+		RedDull:         lipgloss.Color("#FF6F91"),
+	}
 
-	Normal    = lipgloss.AdaptiveColor{Light: "#1A1A1A", Dark: "#dddddd"}
-	NormalDim = lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"}
-
-	Gray          = lipgloss.AdaptiveColor{Light: "#909090", Dark: "#626262"}
-	GrayMid       = lipgloss.AdaptiveColor{Light: "#B2B2B2", Dark: "#4A4A4A"}
-	GrayDark      = lipgloss.AdaptiveColor{Light: "#DDDADA", Dark: "#222222"}
-	GrayBright    = lipgloss.AdaptiveColor{Light: "#847A85", Dark: "#979797"}
-	GrayBrightDim = lipgloss.AdaptiveColor{Light: "#C2B8C2", Dark: "#4D4D4D"}
-
-	Indigo          = lipgloss.AdaptiveColor{Light: "#5A56E0", Dark: "#7571F9"}
-	IndigoDim       = lipgloss.AdaptiveColor{Light: "#9498FF", Dark: "#494690"}
-	IndigoSubtle    = lipgloss.AdaptiveColor{Light: "#7D79F6", Dark: "#514DC1"}
-	IndigoSubtleDim = lipgloss.AdaptiveColor{Light: "#BBBDFF", Dark: "#383584"}
-
-	YellowGreen     = lipgloss.AdaptiveColor{Light: "#04B575", Dark: "#ECFD65"}
-	YellowGreenDull = lipgloss.AdaptiveColor{Light: "#6BCB94", Dark: "#9BA92F"}
-
-	Fuschia        = lipgloss.AdaptiveColor{Light: "#EE6FF8", Dark: "#EE6FF8"}
-	FuchsiaDim     = lipgloss.AdaptiveColor{Light: "#F1A8FF", Dark: "#99519E"}
-	FuchsiaDull    = lipgloss.AdaptiveColor{Dark: "#AD58B4", Light: "#F793FF"}
-	FuchsiaDullDim = lipgloss.AdaptiveColor{Light: "#F6C9FF", Dark: "#6B3A6F"}
-
-	Green    = lipgloss.Color("#04B575")
-	GreenDim = lipgloss.AdaptiveColor{Light: "#72D2B0", Dark: "#0B5137"}
-
-	Red     = lipgloss.AdaptiveColor{Light: "#FF4672", Dark: "#ED567A"}
-	RedDull = lipgloss.AdaptiveColor{Light: "#FF6F91", Dark: "#C74665"}
+	Dark = Colors{
+		WhiteBright:     lipgloss.Color("#FFFDF5"),
+		Normal:          lipgloss.Color("#dddddd"),
+		NormalDim:       lipgloss.Color("#777777"),
+		Gray:            lipgloss.Color("626262"),
+		GrayMid:         lipgloss.Color("#4A4A4A"),
+		GrayDark:        lipgloss.Color("#222222"),
+		GrayBright:      lipgloss.Color("#979797"),
+		GrayBrightDim:   lipgloss.Color("#4D4D4D"),
+		Indigo:          lipgloss.Color("#7571F9"),
+		IndigoDim:       lipgloss.Color("#494690"),
+		IndigoSubtle:    lipgloss.Color("#514DC1"),
+		IndigoSubtleDim: lipgloss.Color("#383584"),
+		YellowGreen:     lipgloss.Color("#ECFD65"),
+		YellowGreenDull: lipgloss.Color("#9BA92F"),
+		Fuschia:         lipgloss.Color("#EE6FF8"),
+		FuchsiaDim:      lipgloss.Color("#99519E"),
+		FuchsiaDull:     lipgloss.Color("#AD58B4"),
+		FuchsiaDullDim:  lipgloss.Color("#6B3A6F"),
+		Green:           lipgloss.Color("#04B575"),
+		GreenDim:        lipgloss.Color("#0B5137"),
+		Red:             lipgloss.Color("#ED567A"),
+		RedDull:         lipgloss.Color("#C74665"),
+	}
 )
+
+type Colors struct {
+	WhiteBright lipgloss.TerminalColor
+
+	Normal    lipgloss.TerminalColor
+	NormalDim lipgloss.TerminalColor
+
+	Gray          lipgloss.TerminalColor
+	GrayMid       lipgloss.TerminalColor
+	GrayDark      lipgloss.TerminalColor
+	GrayBright    lipgloss.TerminalColor
+	GrayBrightDim lipgloss.TerminalColor
+
+	Indigo          lipgloss.TerminalColor
+	IndigoDim       lipgloss.TerminalColor
+	IndigoSubtle    lipgloss.TerminalColor
+	IndigoSubtleDim lipgloss.TerminalColor
+
+	YellowGreen     lipgloss.TerminalColor
+	YellowGreenDull lipgloss.TerminalColor
+
+	Fuschia        lipgloss.TerminalColor
+	FuchsiaDim     lipgloss.TerminalColor
+	FuchsiaDull    lipgloss.TerminalColor
+	FuchsiaDullDim lipgloss.TerminalColor
+
+	Green    lipgloss.TerminalColor
+	GreenDim lipgloss.TerminalColor
+
+	Red     lipgloss.TerminalColor
+	RedDull lipgloss.TerminalColor
+}

--- a/colors/go.mod
+++ b/colors/go.mod
@@ -14,3 +14,5 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 )
+
+replace github.com/charmbracelet/lipgloss => github.com/charmbracelet/lipgloss v0.12.2-0.20240722162534-2390dea254e8

--- a/colors/go.sum
+++ b/colors/go.sum
@@ -1,7 +1,7 @@
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
-github.com/charmbracelet/lipgloss v0.12.1 h1:/gmzszl+pedQpjCOH+wFkZr/N90Snz40J/NR7A0zQcs=
-github.com/charmbracelet/lipgloss v0.12.1/go.mod h1:V2CiwIuhx9S1S1ZlADfOj9HmxeMAORuz5izHb0zGbB8=
+github.com/charmbracelet/lipgloss v0.12.2-0.20240722162534-2390dea254e8 h1:7SMpm8y17K515kM1Q/tiOrSm1jb3hJh94W+LXHWKv+U=
+github.com/charmbracelet/lipgloss v0.12.2-0.20240722162534-2390dea254e8/go.mod h1:LCQCsVTQm+lcQLFSiHwSvQUqRXtry1v/2KCfKxdsCeY=
 github.com/charmbracelet/x/ansi v0.1.4 h1:IEU3D6+dWwPSgZ6HBH+v6oUuZ/nVawMiWj5831KfiLM=
 github.com/charmbracelet/x/ansi v0.1.4/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/go.work.sum
+++ b/go.work.sum
@@ -38,6 +38,7 @@ golang.org/x/term v0.16.0/go.mod h1:yn7UURbUtPyrVJPGPq404EukNFxcm/foM+bV/bfcDsY=
 golang.org/x/term v0.19.0/go.mod h1:2CuTdWZ7KHSQwUzKva0cbMg6q2DMI3Mmxp+gKJbskEk=
 golang.org/x/term v0.21.0/go.mod h1:ooXLefLobQVslOqselCNF4SxFAaoS6KujMbsGzSDmX0=
 golang.org/x/term v0.22.0/go.mod h1:F3qCibpT5AMpCRfhfT53vVJwhLtIVHhB9XDjfFvnMI4=
+golang.org/x/term v0.23.0/go.mod h1:DgV24QBUrK6jhZXl+20l6UWznPlwAHm1Q1mGHtydmSk=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=


### PR DESCRIPTION
TODO
- [ ] update the lipgloss branch to the latest `v2`

Example Usage:

Divides into `Light` and `Dark` colour palettes. In your app, you can switch which colour palette depending on the `TerminalBackgroundMsg`

```go
func NewStyle(isDark bool) Styles {
	color := colors.Light
	if isDark {
    	color = colors.Dark
	}
	return Styles{
    	Normal:        	lipgloss.NewStyle().Foreground(color.Normal),
    	NormalDim:     	lipgloss.NewStyle().Foreground(color.NormalDim),
    	Keyword:       	lipgloss.NewStyle().Foreground(color.Green),
    	KeywordDim:    	lipgloss.NewStyle().Foreground(color.GreenDim),
    	Item:          	lipgloss.NewStyle().PaddingLeft(3),
    	DeletingItem:  	lipgloss.NewStyle().Foreground(color.Red),
    	SelectedItem:  	lipgloss.NewStyle().Foreground(lipgloss.Color("170")),
    	Accent:        	lipgloss.NewStyle().Foreground(color.Fuschia),
}}
```

In your model’s Update:
```go
	case tea.BackgroundColorMsg:
    	isDark := lipgloss.IsDarkColor(msg)
    	// Update styles
    	m.Styles = NewStyle(isDark)
    	m.setBubbleStyles() // sets the styles for all of the submodels/bubbles used by this model
```