### PR TITLE
fix(golden): Removed duplicate fixLineEndings

### DIFF
--- a/exp/golden/golden.go
+++ b/exp/golden/golden.go
@@ -44,7 +44,6 @@ func RequireEqualEscape(tb testing.TB, out []byte, escapes bool) {
 		tb.Fatal(err)
 	}
 
-	goldenBts = fixLineEndings(goldenBts)
 	goldenStr := string(goldenBts)
 	outStr := string(out)
 	if escapes {


### PR DESCRIPTION
- This function does not work correctly when the byte sequence contains a slice like \r\r\n
- This is because we're applying `fixLineEndings(goldenBts)` twice to `goldenBts`(before writing to the file and after reading from it) and once to `out`
- To reproduce, run `go test -v ./... -update` on [https://github.com/caarlos0/teatest-example](https://github.com/caarlos0/teatest-example). Use the latest version of [teatest](https://github.com/charmbracelet/x/tree/main/exp/teatest)
- An alternative solution might be to replace all occurrences of the form \r\r\r\r...\n with \n