### PR TITLE
feat(ansi): add Scanner for splitting ANSI encoded strings.

### DIFF
--- a/ansi/scanner.go
+++ b/ansi/scanner.go
@@ -205,8 +205,19 @@ func (s *Scanner) Scan() bool {
 				}
 				s.escape = false
 			}
-			if s.advance(1, 1) {
-				return true
+			switch c := s.b[s.end]; {
+			case c > US && c < DEL:
+				if s.advance(1, 1) {
+					return true
+				}
+			case c <= US || c == DEL || c < 0xC0:
+				if s.advance(1, 0) {
+					return true
+				}
+			default:
+				if s.advance(1, 1) {
+					return true
+				}
 			}
 		default:
 			if !s.escape {

--- a/ansi/scanner_test.go
+++ b/ansi/scanner_test.go
@@ -105,7 +105,7 @@ func TestScannerLinesWords(t *testing.T) {
 			expected: []scanResult{
 				{true, 0, "\x1b[91m"},
 				{false, 3, "foo"},
-				{false, 1, "\n"},
+				{false, 0, "\n"},
 				{false, 3, "bar"},
 				{true, 0, "\x1b[0"},
 			},
@@ -116,7 +116,7 @@ func TestScannerLinesWords(t *testing.T) {
 			expected: []scanResult{
 				{true, 0, "\x1b[91m"},
 				{false, 3, "foo"},
-				{false, 1, "\r"},
+				{false, 0, "\r"},
 				{false, 3, "bar"},
 				{true, 0, "\x1b[0"},
 			},
@@ -127,7 +127,7 @@ func TestScannerLinesWords(t *testing.T) {
 			expected: []scanResult{
 				{true, 0, "\x1b[91m"},
 				{false, 3, "foo"},
-				{false, 2, "\r\n"},
+				{false, 0, "\r\n"},
 				{false, 3, "bar"},
 				{true, 0, "\x1b[0"},
 			},
@@ -138,7 +138,7 @@ func TestScannerLinesWords(t *testing.T) {
 			expected: []scanResult{
 				{true, 0, "\x1b[91m"},
 				{false, 3, "foo"},
-				{false, 4, "\r\r\r\n"},
+				{false, 0, "\r\r\r\n"},
 				{false, 3, "bar"},
 				{true, 0, "\x1b[0"},
 			},
@@ -150,7 +150,7 @@ func TestScannerLinesWords(t *testing.T) {
 				{true, 0, "\x1b[91m"},
 				{false, 3, "foo"},
 				{false, 1, " "},
-				{false, 2, "\r\n"},
+				{false, 0, "\r\n"},
 				{false, 1, " "},
 				{false, 3, "bar"},
 				{false, 1, " "},
@@ -163,9 +163,9 @@ func TestScannerLinesWords(t *testing.T) {
 			expected: []scanResult{
 				{true, 0, "\x1b[91m"},
 				{false, 3, "foo"},
-				{false, 1, "\n"},
-				{false, 1, "\n"},
-				{false, 2, "\r\n"},
+				{false, 0, "\n"},
+				{false, 0, "\n"},
+				{false, 0, "\r\n"},
 				{false, 3, "bar"},
 				{true, 0, "\x1b[0"},
 			},
@@ -175,10 +175,10 @@ func TestScannerLinesWords(t *testing.T) {
 			input: "   \n\n   \r\n   ",
 			expected: []scanResult{
 				{false, 3, "   "},
-				{false, 1, "\n"},
-				{false, 1, "\n"},
+				{false, 0, "\n"},
+				{false, 0, "\n"},
 				{false, 3, "   "},
-				{false, 2, "\r\n"},
+				{false, 0, "\r\n"},
 				{false, 3, "   "},
 			},
 		},
@@ -252,7 +252,7 @@ func TestScannerLines(t *testing.T) {
 			expected: []scanResult{
 				{true, 0, "\x1b[91m"},
 				{false, 3, "foo"},
-				{false, 1, "\n"},
+				{false, 0, "\n"},
 				{false, 3, "bar"},
 				{true, 0, "\x1b[0"},
 			},
@@ -263,7 +263,7 @@ func TestScannerLines(t *testing.T) {
 			expected: []scanResult{
 				{true, 0, "\x1b[91m"},
 				{false, 4, "foo "},
-				{false, 2, "\r\n"},
+				{false, 0, "\r\n"},
 				{false, 5, " bar "},
 				{true, 0, "\x1b[0"},
 			},
@@ -274,7 +274,7 @@ func TestScannerLines(t *testing.T) {
 			expected: []scanResult{
 				{true, 0, "\x1b[91m"},
 				{false, 4, "foo "},
-				{false, 1, "\r"},
+				{false, 0, "\r"},
 				{false, 5, " bar "},
 				{true, 0, "\x1b[0"},
 			},
@@ -347,7 +347,7 @@ func TestScanner(t *testing.T) {
 			input: "\x1b[91mfoo \r\n bar \x1b[0",
 			expected: []scanResult{
 				{true, 0, "\x1b[91m"},
-				{false, 11, "foo \r\n bar "},
+				{false, 9, "foo \r\n bar "},
 				{true, 0, "\x1b[0"},
 			},
 		},


### PR DESCRIPTION
Hi,

Thought this might be helpful for manipulating styled strings without getting into the details of the Parser and all the encodings of styled strings. It could be very useful in other modules like lipgloss or when using it.

Here are a few samples of functions rewritten using this..

```
// Strip removes ANSI escape codes from a string.
func Strip(s string) string {
	var (
		buf bytes.Buffer // buffer for collecting printable characters
	)
	scanner := NewScanner(s)
	for !scanner.EOF() {
		tk, txt := scanner.Scan()
		switch tk {
		case TextToken:
			buf.WriteString(txt)
		}
	}
	return buf.String()
}
```

```
// Truncate truncates a string to a given length, adding a tail to the
// end if the string is longer than the given length.
// This function is aware of ANSI escape codes and will not break them, and
// accounts for wide-characters (such as East Asians and emojis).
func Truncate1(s string, length int, tail string) string {
	var (
		ignoring  bool
		sb        strings.Builder
		tailWidth = StringWidth(tail)
		width     = 0
	)
	scanner := NewScanner(s)
	for !scanner.EOF() {
		tk, txt := scanner.Scan()
		switch tk {
		case TextToken:
			if ignoring {
				continue
			}
			if txWidth := scanner.Width(); width+txWidth <= length {
				width += txWidth
				sb.WriteString(txt)
				continue
			}
			// text is too big and needs to be truncated
			// read characters until out of space
			// append with tail if there is room
			g := uniseg.NewGraphemes(txt)
			for g.Next() && width+g.Width() <= length-tailWidth {
				sb.WriteString(g.Str())
				width += g.Width()
			}
			if width+tailWidth <= length {
				sb.WriteString(tail)
			}
			ignoring = true

		default:
			sb.WriteString(txt)
		}
	}
	return sb.String()
}
```

I was trying to do something like transpose a line to a column.

`\x1b[31mHi\x1b[0m`

to 

```
\x1b[31mH\x1b[0m
\x1b[31mi\x1b[0m
```

Here is a sample function to do that..
```
// Transpose breaks a line into individual lines for each rune preserving ANSI
// escape codes which are distributed to each new line.
//
// todo minimize the ANSI codes. Currently if there are multiple codes they are
// just concatenated, which may lead to redundancy in some cases.
func Transpose(s string) string {
	var (
		prefix  strings.Builder
		lines   = make([]strings.Builder, 0, len(s))
		scanner = NewScanner(s, ScanRunes)
	)

	for !scanner.EOF() {
		tk, txt := scanner.Scan()
		switch tk {
		case ControlToken:
			prefix.WriteString(txt)
			for i := range lines {
				lines[i].WriteString(txt)
			}
		case RuneToken:
			n := len(lines)
			lines = append(lines, strings.Builder{})
			lines[n].WriteString(prefix.String())
			lines[n].WriteString(txt)
		}
	}
	var sb strings.Builder
	for i, l := range lines {
		if i > 0 {
			sb.WriteString("\n")
		}
		sb.WriteString(l.String())
	}
	return sb.String()
}
```

Let me know if you are interested and if you think it still needs some changes.. 

Thanks.
Tom 
