### PR TITLE
fix: compat layer for ansi 0.3->0.4 migration

### DIFF
--- a/ansi/cursor.go
+++ b/ansi/cursor.go
@@ -163,7 +163,7 @@ func SetCursorPosition(col, row int) string {
 	return "\x1b[" + strconv.Itoa(row) + ";" + strconv.Itoa(col) + "H"
 }
 
-// SetCursorPosition (CUP) returns a sequence for setting the cursor to the
+// MoveCursor (CUP) returns a sequence for setting the cursor to the
 // given row and column.
 //
 //	CSI n ; m H

--- a/ansi/cursor.go
+++ b/ansi/cursor.go
@@ -163,9 +163,27 @@ func SetCursorPosition(col, row int) string {
 	return "\x1b[" + strconv.Itoa(row) + ";" + strconv.Itoa(col) + "H"
 }
 
+// SetCursorPosition (CUP) returns a sequence for setting the cursor to the
+// given row and column.
+//
+//	CSI n ; m H
+//
+// See: https://vt100.net/docs/vt510-rm/CUP.html
+//
+// Deprecated: use SetCursorPosition instead.
+func MoveCursor(col, row int) string {
+	return SetCursorPosition(col, row)
+}
+
 // CursorOrigin is a sequence for moving the cursor to the upper left corner of
 // the display. This is equivalent to `SetCursorPosition(1, 1)`.
 const CursorOrigin = "\x1b[1;1H"
+
+// MoveCursorOrigin is a sequence for moving the cursor to the upper left
+// corner of the display. This is equivalent to `SetCursorPosition(1, 1)`.
+//
+// Deprecated: use CursorOrigin instead.
+const MoveCursorOrigin = CursorOrigin
 
 // SaveCursorPosition (SCP or SCOSC) is a sequence for saving the cursor
 // position.


### PR DESCRIPTION
currently, updating to v0.4.0 is a breaking change... so it'll break any bubbletea app on latest bubbletea version.

I think we can roll this for a while and then remove these deprecated options... wdyt?