### PR TITLE
revert: "fix: set cursor style sequence"

### DIFF
--- a/ansi/cursor.go
+++ b/ansi/cursor.go
@@ -227,7 +227,7 @@ func SetCursorStyle(style int) string {
 	if style < 0 {
 		style = 0
 	}
-	return "\x1b[" + strconv.Itoa(style) + "q"
+	return "\x1b[" + strconv.Itoa(style) + " q"
 }
 
 // SetPointerShape returns a sequence for changing the mouse pointer cursor


### PR DESCRIPTION
Reverts charmbracelet/x#229

DECSCUSR _has_ an intermediate space character `CSI Ps SP q` where `Ps` is a cursor style integer