### PR TITLE
add ReadQueryResponses method that will read ansi responses on windows

### DIFF
--- a/input/driver.go
+++ b/input/driver.go
@@ -53,6 +53,13 @@ func NewDriver(r io.Reader, term string, flags int) (*Driver, error) {
 	return d, nil
 }
 
+// ReadQueryResponses is equivalent to ReadEvents on non-Windows systems.  However,
+// on windows systems this method will pull ansi responses from the tty instead of trying
+// to pull key/mouse input from windows' ReadConsoleInput syscall, which is what ReadEvents does
+func (d *Driver) ReadQueryResponses() (e []Event, err error) {
+	return d.readEvents()
+}
+
 // Cancel cancels the underlying reader.
 func (d *Driver) Cancel() bool {
 	return d.rd.Cancel()


### PR DESCRIPTION
See #248 

Non-windows systems have one way to read events from the terminal: Driver.ReadEvents calls Driver.readEvents, which pulls data from the CancellableReader and parses ANSI data into events.

Windows systems additionally have code that calls into the Windows ReadConsoleInput syscall, which can only read mouse and keyboard events, and will block until an event is received. This syscall cannot be cancelled or timed out.

Currently, there is no way to call the former (which works great!) on Windows.  Bubbletea v2 seems to use code that does the latter from an input pump, and I assume it works great in that context.  However, ReadEvents is used both for the bubbletea input pump and reading ANSI query responses in lipgloss v2.  When used for the latter, the Windows code will hang because ReadConsoleInput isn't used for pulling ANSI query responses and can't be cancelled.

As a result, I would like to split the Driver API into two methods: ReadEvents, to be used from input pumps, and ReadQueryResponses, to be used from queryTerminal & equivalents.  

I've verified that when plugged in to use the new method from windows terminal & standalone CMD terminals, lipgloss v2's `BackgroundColor` will successfully parse the primary DA response and immediately return a null background color.  When used from the windows terminal preview version, lipgloss v2's `BackgroundColor` will actually return the correct background color.