### PR TITLE
fix(ansi): whitespace handling on the last line

### DIFF
--- a/ansi/wrap.go
+++ b/ansi/wrap.go
@@ -378,14 +378,17 @@ func Wrap(s string, limit int, breakpoints string) string {
 		i++
 	}
 
-	if word.Len() != 0 {
-		// Preserve ANSI wrapped spaces at the end of string
+	if wordLen == 0 {
 		if curWidth+space.Len() > limit {
-			buf.WriteByte('\n')
+			curWidth = 0
+		} else {
+			// preserve whitespaces
+			buf.Write(space.Bytes())
 		}
-		addSpace()
+		space.Reset()
 	}
-	buf.Write(word.Bytes())
+
+	addWord()
 
 	return buf.String()
 }

--- a/ansi/wrap_test.go
+++ b/ansi/wrap_test.go
@@ -181,7 +181,7 @@ var wrapCases = []struct {
 	{
 		name:     "extra space style",
 		input:    "\x1b[mfoo \x1b[m",
-		expected: "\x1b[mfoo\n \x1b[m",
+		expected: "\x1b[mfoo\x1b[m",
 		width:    3,
 	},
 	{


### PR DESCRIPTION
This commit fixes a bug where the last line of a wrapped string would preserve spaces at the end of the line and might hard wrap the line with spaces only. This commit changes the behavior to remove any whitespace at the end of the line.

Fixes: https://github.com/charmbracelet/x/issues/286