### PR TITLE
fix(compat): more accurate behavior of SGR 21

### DIFF
--- a/ansi/sgr.go
+++ b/ansi/sgr.go
@@ -46,7 +46,7 @@ var attrStrings = map[int]string{
 	ReverseAttr:                      "7",
 	ConcealAttr:                      "8",
 	StrikethroughAttr:                "9",
-	NoBoldAttr:                       "21",
+	DoubleUnderlineAttr:              "21",
 	NormalIntensityAttr:              "22",
 	NoItalicAttr:                     "23",
 	NoUnderlineAttr:                  "24",

--- a/ansi/style.go
+++ b/ansi/style.go
@@ -127,9 +127,12 @@ func (s Style) Strikethrough() Style {
 	return append(s, strikethroughAttr)
 }
 
-// NoBold appends the no bold style attribute to the style.
-func (s Style) NoBold() Style {
-	return append(s, noBoldAttr)
+// EcmaDoubleUnderline appends the double underline style attribute to the style.
+// Differs from UnderlineStyle(DoubleUnderlineStyle) by using ECMA-compliant
+// SGR 21 instead of SGR 4 subparameter extension.
+// Some terminals may interpret this as "no bold" attribute.
+func (s Style) EcmaDoubleUnderline() Style {
+	return append(s, doubleUnderlineAttr)
 }
 
 // NormalIntensity appends the normal intensity style attribute to the style.
@@ -236,7 +239,7 @@ const (
 	ReverseAttr                      Attr = 7
 	ConcealAttr                      Attr = 8
 	StrikethroughAttr                Attr = 9
-	NoBoldAttr                       Attr = 21 // Some terminals treat this as double underline.
+	DoubleUnderlineAttr              Attr = 21 // Some terminals treat this as no bold.
 	NormalIntensityAttr              Attr = 22
 	NoItalicAttr                     Attr = 23
 	NoUnderlineAttr                  Attr = 24
@@ -298,7 +301,7 @@ const (
 	reverseAttr                      = "7"
 	concealAttr                      = "8"
 	strikethroughAttr                = "9"
-	noBoldAttr                       = "21"
+	doubleUnderlineAttr              = "21"
 	normalIntensityAttr              = "22"
 	noItalicAttr                     = "23"
 	noUnderlineAttr                  = "24"


### PR DESCRIPTION
## What was changed

Switch const key for SGR 21 to a more widely supported variant.

## Rationale

ECMA-48 and most common terminal emulators implement SGR 21 as double underline, which predates SGR 4 underline style extension. This behavior is much more common than "no bold" one.

Currently, `x/ansi` uses `[Nn]oBoldAttr` for SGR 21, but the consensus among terminal emulators (and ECMA-48) is to apply double underline or other visual indicator instead.

```sh
printf '\e[21mTest\e[m'
```

Double underline:

- **ECMA-48**
- WezTerm (flatpak 20240203-110809-5046fc22)
- KDE konsole 23.08.5
- Gnome Terminal Version 3.52.0 for GNOME 46 (Using VTE version 0.76.0 +BIDI +GNUTLS +ICU +SYSTEMD)

Single underline or other visual indicator:

- xterm (372)
- Linux console since Linux 4.17

Normal intensity / no bold:

- [Linux console before Linux 4.17](https://www.man7.org/linux/man-pages/man4/console_codes.4.html#:~:text=before%20Linux%204.17%2C%20this%20value%20set%20normal%20intensity)

## Impact

- This will break apps using the NoBold function, but `x` projects do not guarantee backwards compatibility.
- After a cursory search, `NoBold()` does not seem to be used (at least according to GitHub's search) and impact of the change should be minimal.
- This requires change in [charmbracelet/sequin](https://github.com/charmbracelet/sequin).
