### PR TITLE
feat(input): support parsing xterm window text area size report

### DIFF
--- a/input/input.go
+++ b/input/input.go
@@ -30,9 +30,26 @@ func (e MultiEvent) String() string {
 
 // WindowSizeEvent is used to report the terminal size. Note that Windows does
 // not have support for reporting resizes via SIGWINCH signals and relies on
-// the Windows Console API to report window size changes. See [newCancelreader]
-// and [conInputReader] for more information.
+// the Windows Console API to report window size changes.
 type WindowSizeEvent struct {
+	Width  int
+	Height int
+}
+
+// WindowAreaEvent is used to report the terminal area size in pixels. This is
+// the response from a [ansi.WindowOp] [ansi.ReportWindowSizeWinOp] request.
+// You can use this along with [WindowSizeEvent] to get the terminal cell size.
+//
+// Example:
+//
+//	    // Assuming we already have a WindowSizeEvent
+//		var winsize WindowSizeEvent
+//		switch ev := ev.(type) {
+//		case WindowAreaEvent:
+//		  cellWidth := ev.Width / winsize.Width
+//		  cellHeight := ev.Height / winsize.Height
+//		}
+type WindowAreaEvent struct {
 	Width  int
 	Height int
 }

--- a/input/key_test.go
+++ b/input/key_test.go
@@ -121,6 +121,14 @@ func TestParseSequence(t *testing.T) {
 			[]Event{KeyPressEvent{Code: KeyBackspace, Mod: ModAlt}},
 		},
 
+		// Xterm report window text area size.
+		seqTest{
+			[]byte("\x1b[4;24;80t"),
+			[]Event{
+				WindowAreaEvent{Width: 80, Height: 24},
+			},
+		},
+
 		// Kitty keyboard / CSI u (fixterms)
 		seqTest{
 			[]byte("\x1b[1B"),

--- a/input/parse.go
+++ b/input/parse.go
@@ -504,6 +504,24 @@ func (p *Parser) parseCsi(b []byte) (int, Event) {
 
 			return i, k
 		}
+
+	case 't':
+		param, ok := csi.Param(0, 0)
+		if !ok {
+			break
+		}
+
+		switch param {
+		case 4:
+			// Text area size report CSI t
+			height, _ := csi.Param(1, 0)
+			width, _ := csi.Param(2, 0)
+			return i, WindowAreaEvent{
+				Height: height,
+				Width:  width,
+			}
+		}
+
 	}
 	return i, UnknownEvent(b[:i])
 }


### PR DESCRIPTION
This adds support to parse the xterm window text area size report. This is useful to get the terminal size in pixels and to calculate the cell size.