### PR TITLE
fix(input): kitty: handle ModShift|ModCapsLock as uppercase

### DIFF
--- a/input/kitty.go
+++ b/input/kitty.go
@@ -310,12 +310,12 @@ func parseKittyKeyboard(csi *ansi.CsiSequence) (Event Event) {
 	}
 
 	if len(key.Text) == 0 && unicode.IsPrint(key.Code) &&
-		(key.Mod <= ModShift || key.Mod == ModCapsLock) {
+		(key.Mod <= ModShift || key.Mod == ModCapsLock || key.Mod == ModShift|ModCapsLock) {
 		if key.Mod == 0 {
 			key.Text = string(key.Code)
 		} else {
 			desiredCase := unicode.ToLower
-			if key.Mod == ModShift || key.Mod == ModCapsLock {
+			if key.Mod.Contains(ModShift) || key.Mod.Contains(ModCapsLock) {
 				desiredCase = unicode.ToUpper
 			}
 			if key.ShiftedCode != 0 {


### PR DESCRIPTION
This fixes an issue when both shift and caps-lock are on at the same time. In this case, the key should be treated as uppercase as if one of the two was pressed.