### PR TITLE
Fix handling for `ED (Erase in Display)` control sequence

### DIFF
--- a/vt/csi_screen.go
+++ b/vt/csi_screen.go
@@ -6,15 +6,18 @@ import (
 
 func (t *Terminal) handleScreen() {
 	width, height := t.Width(), t.Height()
-	_, y := t.scr.CursorPosition()
+	x, y := t.scr.CursorPosition()
 
 	switch t.parser.Cmd() {
 	case 'J': // Erase in Display [ansi.ED]
 		count, _ := t.parser.Param(0, 0)
 		switch count {
-		case 0: // Erase screen below (including cursor)
-			rect := Rect(0, y, width, height-y)
-			t.scr.Fill(t.scr.blankCell(), rect)
+		case 0: // Erase screen below (from after cursor position)
+			rect1 := Rect(x, y, width, 1)            // cursor to end of line
+			rect2 := Rect(0, y+1, width, height-y-1) // next line onwards
+			for _, rect := range []Rectangle{rect1, rect2} {
+				t.scr.Fill(t.scr.blankCell(), rect)
+			}
 		case 1: // Erase screen above (including cursor)
 			rect := Rect(0, 0, width, y+1)
 			t.scr.Fill(t.scr.blankCell(), rect)

--- a/vt/terminal_test.go
+++ b/vt/terminal_test.go
@@ -1402,7 +1402,7 @@ var cases = []struct {
 		w:    8, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -1411,7 +1411,7 @@ var cases = []struct {
 		},
 		want: []string{
 			"ABC     ",
-			"        ",
+			"D       ",
 			"        ",
 		},
 		pos: Pos(1, 1),
@@ -1431,7 +1431,7 @@ var cases = []struct {
 		},
 		want: []string{
 			"ABC     ",
-			"        ",
+			"D       ",
 			"        ",
 		},
 		pos: Pos(1, 1),
@@ -1441,26 +1441,26 @@ var cases = []struct {
 		w:    8, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"AB橋C\r\n",
 			"DE橋F\r\n",
 			"GH橋I",
-			"\x1b[2;4H",
+			"\x1b[2;3H", // move to 2nd row 3rd column
 			"\x1b[0J",
 		},
 		want: []string{
 			"AB橋C   ",
-			"        ",
+			"DE      ",
 			"        ",
 		},
-		pos: Pos(3, 1),
+		pos: Pos(2, 1),
 	},
 	{
 		name: "ED Simple Erase Above",
 		w:    8, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",

--- a/vt/terminal_test.go
+++ b/vt/terminal_test.go
@@ -70,7 +70,7 @@ var cases = []struct {
 		w:    10, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[?W",   // reset tab stops
 			"\x1b[?6h",  // origin mode
 			"\x1b[?69h", // left margin mode
@@ -114,7 +114,7 @@ var cases = []struct {
 		w:    10, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[?W",   // reset tab stops
 			"\x1b[?69h", // enable left/right margins
 			"\x1b[3;6s", // scroll region left/right
@@ -148,7 +148,7 @@ var cases = []struct {
 		w:    10, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[?69h", // enable left/right margin mode
 			"\x1b[2;5s", // set left/right margin
 			"\x1b[4G",   // move to column 4
@@ -164,7 +164,7 @@ var cases = []struct {
 		w:    10, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[?69h", // enable left/right margin mode
 			"\x1b[2;5s", // set left/right margin
 			"\x1b[4G",   // move to column 4
@@ -181,7 +181,7 @@ var cases = []struct {
 		w:    10, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[?6h",  // enable origin mode
 			"\x1b[?69h", // enable left/right margin mode
 			"\x1b[2;5s", // set left/right margin
@@ -233,7 +233,7 @@ var cases = []struct {
 			"\x1b[?7h",  // enable wraparound
 			"\x1b[?45h", // enable reverse wrap
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[10G",  // move to end of line
 			"AB",        // write and wrap
 			"\x1b[D",    // move back one
@@ -253,7 +253,7 @@ var cases = []struct {
 	// 		"\x1b[?7h",    // enable wraparound
 	// 		"\x1b[?1045h", // enable extended reverse wrap
 	// 		"\x1b[1;1H",   // move to top-left
-	// 		"\x1b[0J",     // clear screen
+	// 		"\x1b[2J",     // clear screen
 	// 		"A\nB",
 	// 		"\x1b[2D", // move back two
 	// 		"X",
@@ -271,7 +271,7 @@ var cases = []struct {
 	// 		"\x1b[?7h",    // enable wraparound
 	// 		"\x1b[?1045h", // enable extended reverse wrap
 	// 		"\x1b[1;1H",   // move to top-left
-	// 		"\x1b[0J",     // clear screen
+	// 		"\x1b[2J",     // clear screen
 	// 		"\x1b[1;3r",   // set scrolling region
 	// 		"A\nB",
 	// 		"\x1b[D",   // move back one
@@ -291,7 +291,7 @@ var cases = []struct {
 	// 	w:    10, h: 3,
 	// 	input: []string{
 	// 		"\x1b[1;1H", // move to top-left
-	// 		"\x1b[0J",   // clear screen
+	// 		"\x1b[2J",   // clear screen
 	// 		"\x1b[?45h", // enable reverse wrap
 	// 		"\x1b[3r",   // set scroll region
 	// 		"\b",        // backspace
@@ -342,7 +342,7 @@ var cases = []struct {
 		w:    10, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\n\n\n\n",  // move down 4 lines
 			"\x1b[1;3r", // set scrolling region
 			"A",
@@ -362,7 +362,7 @@ var cases = []struct {
 		w:    10, h: 5,
 		input: []string{
 			"\x1b[1;1H",  // move to top-left
-			"\x1b[0J",    // clear screen
+			"\x1b[2J",    // clear screen
 			"\n\n\n\n\n", // move down 5 lines
 			"\x1b[1;3r",  // set scrolling region
 			"A",
@@ -386,7 +386,7 @@ var cases = []struct {
 		w:    10, h: 2,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[2;3H", // move to row 2, col 3
 			"A",
 		},
@@ -401,7 +401,7 @@ var cases = []struct {
 		w:    10, h: 3,
 		input: []string{
 			"\x1b[1;1H",     // move to top-left
-			"\x1b[0J",       // clear screen
+			"\x1b[2J",       // clear screen
 			"\x1b[500;500H", // move way off screen
 			"A",
 		},
@@ -417,7 +417,7 @@ var cases = []struct {
 		w:    10, h: 2,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[2;3r", // scroll region top/bottom
 			"\x1b[?6h",  // origin mode
 			"\x1b[1;1H", // move to top-left
@@ -434,7 +434,7 @@ var cases = []struct {
 		w:    10, h: 2,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[?69h", // enable left/right margins
 			"\x1b[3;5s", // scroll region left/right
 			"\x1b[2;3r", // scroll region top/bottom
@@ -453,7 +453,7 @@ var cases = []struct {
 		w:    10, h: 3,
 		input: []string{
 			"\x1b[1;1H",     // move to top-left
-			"\x1b[0J",       // clear screen
+			"\x1b[2J",       // clear screen
 			"\x1b[?69h",     // enable left/right margins
 			"\x1b[3;5s",     // scroll region left/right
 			"\x1b[2;3r",     // scroll region top/bottom
@@ -517,7 +517,7 @@ var cases = []struct {
 		w:    10, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[?69h", // enable left/right margins
 			"\x1b[3;5s", // scroll region left/right
 			"\x1b[1G",   // move to left
@@ -534,7 +534,7 @@ var cases = []struct {
 		w:    10, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[?69h", // enable left/right margins
 			"\x1b[3;5s", // scroll region left/right
 			"\x1b[6G",   // move to right of margin
@@ -553,7 +553,7 @@ var cases = []struct {
 		w:    10, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[3;1H", // move to row 3
 			"A",
 			"\x1b[2A", // cursor up 2
@@ -571,7 +571,7 @@ var cases = []struct {
 		w:    10, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[2;4r", // set scrolling region
 			"\x1b[3;1H", // move to row 3
 			"A",
@@ -591,7 +591,7 @@ var cases = []struct {
 		w:    10, h: 5,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[3;5r", // set scrolling region
 			"\x1b[3;1H", // move to row 3
 			"A",
@@ -615,7 +615,7 @@ var cases = []struct {
 		w:    8, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -634,7 +634,7 @@ var cases = []struct {
 		w:    8, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -654,7 +654,7 @@ var cases = []struct {
 		w:    8, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI\r\n",
@@ -676,7 +676,7 @@ var cases = []struct {
 		w:    8, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC123\r\n",
 			"DEF456\r\n",
 			"GHI789",
@@ -699,7 +699,7 @@ var cases = []struct {
 		w:    8, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -719,7 +719,7 @@ var cases = []struct {
 		w:    8, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -739,7 +739,7 @@ var cases = []struct {
 		w:    8, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI\r\n",
@@ -761,7 +761,7 @@ var cases = []struct {
 		w:    8, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC123\r\n",
 			"DEF456\r\n",
 			"GHI789",
@@ -808,7 +808,7 @@ var cases = []struct {
 		w:    8, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC123",
 			"\x1b[?69h", // enable left/right margins
 			"\x1b[3;5s", // scroll region left/right
@@ -823,7 +823,7 @@ var cases = []struct {
 		w:    8, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC123",
 			"\x1b[?69h", // enable left/right margins
 			"\x1b[3;5s", // scroll region left/right
@@ -838,7 +838,7 @@ var cases = []struct {
 		w:    10, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"A橋123",
 			"\x1b[3G",
 			"\x1b[P",
@@ -853,7 +853,7 @@ var cases = []struct {
 		w:    8, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -873,7 +873,7 @@ var cases = []struct {
 		w:    8, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -893,7 +893,7 @@ var cases = []struct {
 		w:    8, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -913,7 +913,7 @@ var cases = []struct {
 		w:    8, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -935,7 +935,7 @@ var cases = []struct {
 		w:    8, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -955,7 +955,7 @@ var cases = []struct {
 		w:    8, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -977,7 +977,7 @@ var cases = []struct {
 		w:    8, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -999,7 +999,7 @@ var cases = []struct {
 		w:    8, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -1081,7 +1081,7 @@ var cases = []struct {
 		w:    10, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[?69h", // enable left/right margins
 			"\x1b[1;3s", // scroll region left/right
 			"\x1b[4G",
@@ -1173,7 +1173,7 @@ var cases = []struct {
 		w:    10, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABCDE",
 			"\x1b[?69h", // enable left/right margins
 			"\x1b[1;3s", // scroll region left/right
@@ -1262,7 +1262,7 @@ var cases = []struct {
 		w:    10, h: 2,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"A",
 			"\x1bD", // index
 			"X",
@@ -1278,7 +1278,7 @@ var cases = []struct {
 		w:    10, h: 2,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[2;1H", // move to bottom-left
 			"A",
 			"\x1bD", // index
@@ -1295,7 +1295,7 @@ var cases = []struct {
 		w:    10, h: 2,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[1;3r", // scroll region
 			"A",
 			"\x1bD", // index
@@ -1312,7 +1312,7 @@ var cases = []struct {
 		w:    10, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[1;3r", // scroll region
 			"\x1b[4;1H", // below scroll region
 			"B",
@@ -1334,7 +1334,7 @@ var cases = []struct {
 		w:    10, h: 5,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[1;3r", // scroll region
 			"\x1b[3;1H", // move to last row of region
 			"A",
@@ -1356,7 +1356,7 @@ var cases = []struct {
 		w:    10, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[?69h", // enable left/right margins
 			"\x1b[1;3r", // scroll region top/bottom
 			"\x1b[3;5s", // scroll region left/right
@@ -1378,7 +1378,7 @@ var cases = []struct {
 		w:    10, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"AAAAAA\r\n",
 			"AAAAAA\r\n",
 			"AAAAAA",
@@ -1479,7 +1479,7 @@ var cases = []struct {
 		w:    8, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -1500,7 +1500,7 @@ var cases = []struct {
 		w:    10, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"A\r\n",
 			"B\r\n",
 			"C\r\n",
@@ -1521,7 +1521,7 @@ var cases = []struct {
 		w:    10, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"A\r\n",
 			"B\r\n",
 			"C",
@@ -1541,7 +1541,7 @@ var cases = []struct {
 		w:    10, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"A\r\n",
 			"B\r\n",
 			"C",
@@ -1562,7 +1562,7 @@ var cases = []struct {
 		w:    10, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"A\r\n",
 			"B\r\n",
 			"C",
@@ -1582,7 +1582,7 @@ var cases = []struct {
 		w:    10, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -1604,7 +1604,7 @@ var cases = []struct {
 		w:    10, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -1627,7 +1627,7 @@ var cases = []struct {
 		w:    10, h: 4,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -1650,7 +1650,7 @@ var cases = []struct {
 		w:    10, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -1669,7 +1669,7 @@ var cases = []struct {
 		w:    10, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC\r\n",
 			"DEF\r\n",
 			"GHI",
@@ -1689,7 +1689,7 @@ var cases = []struct {
 		w:    10, h: 3,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"ABC123\r\n",
 			"DEF456\r\n",
 			"GHI789",
@@ -1732,7 +1732,7 @@ var cases = []struct {
 		w:    10, h: 5,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"top",
 			"\x1b[5;1H",
 			"ABCDEF",
@@ -1755,7 +1755,7 @@ var cases = []struct {
 		w:    23, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[?W",   // reset tabs
 			"\t",        // tab to first stop
 			"\x1b[g",    // clear current tab stop
@@ -1770,7 +1770,7 @@ var cases = []struct {
 		w:    23, h: 1,
 		input: []string{
 			"\x1b[1;1H", // move to top-left
-			"\x1b[0J",   // clear screen
+			"\x1b[2J",   // clear screen
 			"\x1b[?W",   // reset tabs
 			"\x1b[3g",   // clear all tab stops
 			"\x1b[1G",   // move back to start


### PR DESCRIPTION
The changes introduced in this PR are:

1. In `vt/csi_screen.go`, the `ED (Erase in Display)` command `case 0` implementation has been updated to handle erasing from the cursor position more precisely.
  The key changes are:
    - Now properly handles erasing from the cursor position by splitting into two rectangles
    - First rectangle erases from cursor to end of current line
    - Second rectangle erases all lines below current line

2. In `vt/terminal_test.go`, all test cases have been updated to use `\x1b[2J` (clear entire screen) instead of `\x1b[0J` (clear from cursor down) for initialization. 

3. `ED` command test cases have also been updated to reflect the updated implementation. 

Ref: [Wikipedia CSI codes](https://en.wikipedia.org/wiki/ANSI_escape_code#Control_Sequence_Introducer_commands), [VT100 ED docs](https://vt100.net/docs/vt510-rm/ED.html)