### PR TITLE
feat(ansi): define Method and make wcwidth aware variants

### DIFF
--- a/ansi/method.go
+++ b/ansi/method.go
@@ -1,0 +1,172 @@
+package ansi
+
+// Method is a type that represents the how the renderer should calculate the
+// display width of cells.
+type Method uint8
+
+// Display width modes.
+const (
+	WcWidth Method = iota
+	GraphemeWidth
+)
+
+// StringWidth returns the width of a string in cells. This is the number of
+// cells that the string will occupy when printed in a terminal. ANSI escape
+// codes are ignored and wide characters (such as East Asians and emojis) are
+// accounted for.
+func (m Method) StringWidth(s string) int {
+	return stringWidth(m, s)
+}
+
+// Truncate truncates a string to a given length, adding a tail to the end if
+// the string is longer than the given length. This function is aware of ANSI
+// escape codes and will not break them, and accounts for wide-characters (such
+// as East-Asian characters and emojis).
+func (m Method) Truncate(s string, length int, tail string) string {
+	return truncate(m, s, length, tail)
+}
+
+// TruncateLeft truncates a string to a given length, adding a prefix to the
+// beginning if the string is longer than the given length. This function is
+// aware of ANSI escape codes and will not break them, and accounts for
+// wide-characters (such as East-Asian characters and emojis).
+func (m Method) TruncateLeft(s string, length int, prefix string) string {
+	return truncateLeft(m, s, length, prefix)
+}
+
+// Cut the string, without adding any prefix or tail strings. This function is
+// aware of ANSI escape codes and will not break them, and accounts for
+// wide-characters (such as East-Asian characters and emojis). Note that the
+// [left] parameter is inclusive, while [right] isn't.
+func (m Method) Cut(s string, left, right int) string {
+	return cut(m, s, left, right)
+}
+
+// Hardwrap wraps a string or a block of text to a given line length, breaking
+// word boundaries. This will preserve ANSI escape codes and will account for
+// wide-characters in the string.
+// When preserveSpace is true, spaces at the beginning of a line will be
+// preserved.
+// This treats the text as a sequence of graphemes.
+func (m Method) Hardwrap(s string, length int, preserveSpace bool) string {
+	return hardwrap(m, s, length, preserveSpace)
+}
+
+// Wordwrap wraps a string or a block of text to a given line length, not
+// breaking word boundaries. This will preserve ANSI escape codes and will
+// account for wide-characters in the string.
+// The breakpoints string is a list of characters that are considered
+// breakpoints for word wrapping. A hyphen (-) is always considered a
+// breakpoint.
+//
+// Note: breakpoints must be a string of 1-cell wide rune characters.
+func (m Method) Wordwrap(s string, length int, breakpoints string) string {
+	return wordwrap(m, s, length, breakpoints)
+}
+
+// Wrap wraps a string or a block of text to a given line length, breaking word
+// boundaries if necessary. This will preserve ANSI escape codes and will
+// account for wide-characters in the string. The breakpoints string is a list
+// of characters that are considered breakpoints for word wrapping. A hyphen
+// (-) is always considered a breakpoint.
+//
+// Note: breakpoints must be a string of 1-cell wide rune characters.
+func (m Method) Wrap(s string, length int, breakpoints string) string {
+	return wrap(m, s, length, breakpoints)
+}
+
+// DecodeSequence decodes the first ANSI escape sequence or a printable
+// grapheme from the given data. It returns the sequence slice, the number of
+// bytes read, the cell width for each sequence, and the new state.
+//
+// The cell width will always be 0 for control and escape sequences, 1 for
+// ASCII printable characters, and the number of cells other Unicode characters
+// occupy. It uses the uniseg package to calculate the width of Unicode
+// graphemes and characters. This means it will always do grapheme clustering
+// (mode 2027).
+//
+// Passing a non-nil [*Parser] as the last argument will allow the decoder to
+// collect sequence parameters, data, and commands. The parser cmd will have
+// the packed command value that contains intermediate and marker characters.
+// In the case of a OSC sequence, the cmd will be the OSC command number. Use
+// [Command] and [Parameter] types to unpack command intermediates and markers as well
+// as parameters.
+//
+// Zero [Command] means the CSI, DCS, or ESC sequence is invalid. Moreover, checking the
+// validity of other data sequences, OSC, DCS, etc, will require checking for
+// the returned sequence terminator bytes such as ST (ESC \\) and BEL).
+//
+// We store the command byte in [Command] in the most significant byte, the
+// marker byte in the next byte, and the intermediate byte in the least
+// significant byte. This is done to avoid using a struct to store the command
+// and its intermediates and markers. The command byte is always the least
+// significant byte i.e. [Cmd & 0xff]. Use the [Command] type to unpack the
+// command, intermediate, and marker bytes. Note that we only collect the last
+// marker character and intermediate byte.
+//
+// The [p.Params] slice will contain the parameters of the sequence. Any
+// sub-parameter will have the [parser.HasMoreFlag] set. Use the [Parameter] type
+// to unpack the parameters.
+//
+// Example:
+//
+//	var state byte // the initial state is always zero [NormalState]
+//	p := NewParser(32, 1024) // create a new parser with a 32 params buffer and 1024 data buffer (optional)
+//	input := []byte("\x1b[31mHello, World!\x1b[0m")
+//	for len(input) > 0 {
+//		seq, width, n, newState := DecodeSequence(input, state, p)
+//		log.Printf("seq: %q, width: %d", seq, width)
+//		state = newState
+//		input = input[n:]
+//	}
+func (m Method) DecodeSequence(data []byte, state byte, p *Parser) (seq []byte, width, n int, newState byte) {
+	return decodeSequence(m, data, state, p)
+}
+
+// DecodeSequenceInString decodes the first ANSI escape sequence or a printable
+// grapheme from the given data. It returns the sequence slice, the number of
+// bytes read, the cell width for each sequence, and the new state.
+//
+// The cell width will always be 0 for control and escape sequences, 1 for
+// ASCII printable characters, and the number of cells other Unicode characters
+// occupy. It uses the uniseg package to calculate the width of Unicode
+// graphemes and characters. This means it will always do grapheme clustering
+// (mode 2027).
+//
+// Passing a non-nil [*Parser] as the last argument will allow the decoder to
+// collect sequence parameters, data, and commands. The parser cmd will have
+// the packed command value that contains intermediate and marker characters.
+// In the case of a OSC sequence, the cmd will be the OSC command number. Use
+// [Command] and [Parameter] types to unpack command intermediates and markers as well
+// as parameters.
+//
+// Zero [Command] means the CSI, DCS, or ESC sequence is invalid. Moreover, checking the
+// validity of other data sequences, OSC, DCS, etc, will require checking for
+// the returned sequence terminator bytes such as ST (ESC \\) and BEL).
+//
+// We store the command byte in [Command] in the most significant byte, the
+// marker byte in the next byte, and the intermediate byte in the least
+// significant byte. This is done to avoid using a struct to store the command
+// and its intermediates and markers. The command byte is always the least
+// significant byte i.e. [Cmd & 0xff]. Use the [Command] type to unpack the
+// command, intermediate, and marker bytes. Note that we only collect the last
+// marker character and intermediate byte.
+//
+// The [p.Params] slice will contain the parameters of the sequence. Any
+// sub-parameter will have the [parser.HasMoreFlag] set. Use the [Parameter] type
+// to unpack the parameters.
+//
+// Example:
+//
+//	var state byte // the initial state is always zero [NormalState]
+//	p := NewParser(32, 1024) // create a new parser with a 32 params buffer and 1024 data buffer (optional)
+//	input := []byte("\x1b[31mHello, World!\x1b[0m")
+//	for len(input) > 0 {
+//		seq, width, n, newState := DecodeSequenceInString(input, state, p)
+//		log.Printf("seq: %q, width: %d", seq, width)
+//		state = newState
+//		input = input[n:]
+//	}
+func (m Method) DecodeSequenceInString(data string, state byte, p *Parser) (seq string, width, n int, newState byte) {
+	return decodeSequence(m, data, state, p)
+}

--- a/ansi/parser_decode.go
+++ b/ansi/parser_decode.go
@@ -4,6 +4,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/charmbracelet/x/ansi/parser"
+	"github.com/mattn/go-runewidth"
 	"github.com/rivo/uniseg"
 )
 
@@ -65,7 +66,63 @@ const (
 //		state = newState
 //		input = input[n:]
 //	}
+//
+// This function treats the text as a sequence of grapheme clusters.
 func DecodeSequence[T string | []byte](b T, state byte, p *Parser) (seq T, width int, n int, newState byte) {
+	return decodeSequence(GraphemeWidth, b, state, p)
+}
+
+// WcDecodeSequence decodes the first ANSI escape sequence or a printable
+// grapheme from the given data. It returns the sequence slice, the number of
+// bytes read, the cell width for each sequence, and the new state.
+//
+// The cell width will always be 0 for control and escape sequences, 1 for
+// ASCII printable characters, and the number of cells other Unicode characters
+// occupy. It uses the uniseg package to calculate the width of Unicode
+// graphemes and characters. This means it will always do grapheme clustering
+// (mode 2027).
+//
+// Passing a non-nil [*Parser] as the last argument will allow the decoder to
+// collect sequence parameters, data, and commands. The parser cmd will have
+// the packed command value that contains intermediate and marker characters.
+// In the case of a OSC sequence, the cmd will be the OSC command number. Use
+// [Command] and [Parameter] types to unpack command intermediates and markers as well
+// as parameters.
+//
+// Zero [Command] means the CSI, DCS, or ESC sequence is invalid. Moreover, checking the
+// validity of other data sequences, OSC, DCS, etc, will require checking for
+// the returned sequence terminator bytes such as ST (ESC \\) and BEL).
+//
+// We store the command byte in [Command] in the most significant byte, the
+// marker byte in the next byte, and the intermediate byte in the least
+// significant byte. This is done to avoid using a struct to store the command
+// and its intermediates and markers. The command byte is always the least
+// significant byte i.e. [Cmd & 0xff]. Use the [Command] type to unpack the
+// command, intermediate, and marker bytes. Note that we only collect the last
+// marker character and intermediate byte.
+//
+// The [p.Params] slice will contain the parameters of the sequence. Any
+// sub-parameter will have the [parser.HasMoreFlag] set. Use the [Parameter] type
+// to unpack the parameters.
+//
+// Example:
+//
+//	var state byte // the initial state is always zero [NormalState]
+//	p := NewParser(32, 1024) // create a new parser with a 32 params buffer and 1024 data buffer (optional)
+//	input := []byte("\x1b[31mHello, World!\x1b[0m")
+//	for len(input) > 0 {
+//		seq, width, n, newState := WcDecodeSequence(input, state, p)
+//		log.Printf("seq: %q, width: %d", seq, width)
+//		state = newState
+//		input = input[n:]
+//	}
+//
+// This function treats the text as a sequence of wide characters and runes.
+func WcDecodeSequence[T string | []byte](b T, state byte, p *Parser) (seq T, width int, n int, newState byte) {
+	return decodeSequence(WcWidth, b, state, p)
+}
+
+func decodeSequence[T string | []byte](m Method, b T, state State, p *Parser) (seq T, width int, n int, newState byte) {
 	for i := 0; i < len(b); i++ {
 		c := b[i]
 
@@ -120,6 +177,9 @@ func DecodeSequence[T string | []byte](b T, state byte, p *Parser) (seq T, width
 
 			if utf8.RuneStart(c) {
 				seq, _, width, _ = FirstGraphemeCluster(b, -1)
+				if m == WcWidth {
+					width = runewidth.StringWidth(string(seq))
+				}
 				i += len(seq)
 				return b[:i], width, i, NormalState
 			}

--- a/ansi/parser_decode.go
+++ b/ansi/parser_decode.go
@@ -72,7 +72,7 @@ func DecodeSequence[T string | []byte](b T, state byte, p *Parser) (seq T, width
 	return decodeSequence(GraphemeWidth, b, state, p)
 }
 
-// WcDecodeSequence decodes the first ANSI escape sequence or a printable
+// DecodeSequenceWc decodes the first ANSI escape sequence or a printable
 // grapheme from the given data. It returns the sequence slice, the number of
 // bytes read, the cell width for each sequence, and the new state.
 //
@@ -111,14 +111,14 @@ func DecodeSequence[T string | []byte](b T, state byte, p *Parser) (seq T, width
 //	p := NewParser(32, 1024) // create a new parser with a 32 params buffer and 1024 data buffer (optional)
 //	input := []byte("\x1b[31mHello, World!\x1b[0m")
 //	for len(input) > 0 {
-//		seq, width, n, newState := WcDecodeSequence(input, state, p)
+//		seq, width, n, newState := DecodeSequenceWc(input, state, p)
 //		log.Printf("seq: %q, width: %d", seq, width)
 //		state = newState
 //		input = input[n:]
 //	}
 //
 // This function treats the text as a sequence of wide characters and runes.
-func WcDecodeSequence[T string | []byte](b T, state byte, p *Parser) (seq T, width int, n int, newState byte) {
+func DecodeSequenceWc[T string | []byte](b T, state byte, p *Parser) (seq T, width int, n int, newState byte) {
 	return decodeSequence(WcWidth, b, state, p)
 }
 

--- a/ansi/truncate.go
+++ b/ansi/truncate.go
@@ -17,12 +17,12 @@ func Cut(s string, left, right int) string {
 	return cut(GraphemeWidth, s, left, right)
 }
 
-// WcCut the string, without adding any prefix or tail strings. This function is
+// CutWc the string, without adding any prefix or tail strings. This function is
 // aware of ANSI escape codes and will not break them, and accounts for
 // wide-characters (such as East-Asian characters and emojis). Note that the
 // [left] parameter is inclusive, while [right] isn't.
 // This treats the text as a sequence of wide characters and runes.
-func WcCut(s string, left, right int) string {
+func CutWc(s string, left, right int) string {
 	return cut(WcWidth, s, left, right)
 }
 
@@ -34,8 +34,8 @@ func cut(m Method, s string, left, right int) string {
 	truncate := Truncate
 	truncateLeft := TruncateLeft
 	if m == WcWidth {
-		truncate = WcTruncate
-		truncateLeft = WcTruncate
+		truncate = TruncateWc
+		truncateLeft = TruncateWc
 	}
 
 	if left == 0 {
@@ -53,12 +53,12 @@ func Truncate(s string, length int, tail string) string {
 	return truncate(GraphemeWidth, s, length, tail)
 }
 
-// WcTruncate truncates a string to a given length, adding a tail to the end if
+// TruncateWc truncates a string to a given length, adding a tail to the end if
 // the string is longer than the given length. This function is aware of ANSI
 // escape codes and will not break them, and accounts for wide-characters (such
 // as East-Asian characters and emojis).
 // This treats the text as a sequence of wide characters and runes.
-func WcTruncate(s string, length int, tail string) string {
+func TruncateWc(s string, length int, tail string) string {
 	return truncate(WcWidth, s, length, tail)
 }
 
@@ -170,12 +170,12 @@ func TruncateLeft(s string, n int, prefix string) string {
 	return truncateLeft(GraphemeWidth, s, n, prefix)
 }
 
-// WcTruncateLeft truncates a string from the left side by removing n characters,
+// TruncateLeftWc truncates a string from the left side by removing n characters,
 // adding a prefix to the beginning if the string is longer than n.
 // This function is aware of ANSI escape codes and will not break them, and
 // accounts for wide-characters (such as East-Asian characters and emojis).
 // This treats the text as a sequence of wide characters and runes.
-func WcTruncateLeft(s string, n int, prefix string) string {
+func TruncateLeftWc(s string, n int, prefix string) string {
 	return truncateLeft(WcWidth, s, n, prefix)
 }
 

--- a/ansi/truncate.go
+++ b/ansi/truncate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/charmbracelet/x/ansi/parser"
+	"github.com/mattn/go-runewidth"
 	"github.com/rivo/uniseg"
 )
 
@@ -11,22 +12,57 @@ import (
 // aware of ANSI escape codes and will not break them, and accounts for
 // wide-characters (such as East-Asian characters and emojis). Note that the
 // [left] parameter is inclusive, while [right] isn't.
+// This treats the text as a sequence of graphemes.
 func Cut(s string, left, right int) string {
+	return cut(GraphemeWidth, s, left, right)
+}
+
+// WcCut the string, without adding any prefix or tail strings. This function is
+// aware of ANSI escape codes and will not break them, and accounts for
+// wide-characters (such as East-Asian characters and emojis). Note that the
+// [left] parameter is inclusive, while [right] isn't.
+// This treats the text as a sequence of wide characters and runes.
+func WcCut(s string, left, right int) string {
+	return cut(WcWidth, s, left, right)
+}
+
+func cut(m Method, s string, left, right int) string {
 	if right <= left {
 		return ""
 	}
 
-	if left == 0 {
-		return Truncate(s, right, "")
+	truncate := Truncate
+	truncateLeft := TruncateLeft
+	if m == WcWidth {
+		truncate = WcTruncate
+		truncateLeft = WcTruncate
 	}
-	return TruncateLeft(Truncate(s, right, ""), left, "")
+
+	if left == 0 {
+		return truncate(s, right, "")
+	}
+	return truncateLeft(Truncate(s, right, ""), left, "")
 }
 
 // Truncate truncates a string to a given length, adding a tail to the end if
 // the string is longer than the given length. This function is aware of ANSI
 // escape codes and will not break them, and accounts for wide-characters (such
 // as East-Asian characters and emojis).
+// This treats the text as a sequence of graphemes.
 func Truncate(s string, length int, tail string) string {
+	return truncate(GraphemeWidth, s, length, tail)
+}
+
+// WcTruncate truncates a string to a given length, adding a tail to the end if
+// the string is longer than the given length. This function is aware of ANSI
+// escape codes and will not break them, and accounts for wide-characters (such
+// as East-Asian characters and emojis).
+// This treats the text as a sequence of wide characters and runes.
+func WcTruncate(s string, length int, tail string) string {
+	return truncate(WcWidth, s, length, tail)
+}
+
+func truncate(m Method, s string, length int, tail string) string {
 	if sw := StringWidth(s); sw <= length {
 		return s
 	}
@@ -57,6 +93,9 @@ func Truncate(s string, length int, tail string) string {
 			// This action happens when we transition to the Utf8State.
 			var width int
 			cluster, _, width, _ = uniseg.FirstGraphemeCluster(b[i:], -1)
+			if m == WcWidth {
+				width = runewidth.StringWidth(string(cluster))
+			}
 
 			// increment the index by the length of the cluster
 			i += len(cluster)
@@ -126,7 +165,21 @@ func Truncate(s string, length int, tail string) string {
 // adding a prefix to the beginning if the string is longer than n.
 // This function is aware of ANSI escape codes and will not break them, and
 // accounts for wide-characters (such as East-Asian characters and emojis).
+// This treats the text as a sequence of graphemes.
 func TruncateLeft(s string, n int, prefix string) string {
+	return truncateLeft(GraphemeWidth, s, n, prefix)
+}
+
+// WcTruncateLeft truncates a string from the left side by removing n characters,
+// adding a prefix to the beginning if the string is longer than n.
+// This function is aware of ANSI escape codes and will not break them, and
+// accounts for wide-characters (such as East-Asian characters and emojis).
+// This treats the text as a sequence of wide characters and runes.
+func WcTruncateLeft(s string, n int, prefix string) string {
+	return truncateLeft(WcWidth, s, n, prefix)
+}
+
+func truncateLeft(m Method, s string, n int, prefix string) string {
 	if n <= 0 {
 		return s
 	}
@@ -149,6 +202,9 @@ func TruncateLeft(s string, n int, prefix string) string {
 		if state == parser.Utf8State {
 			var width int
 			cluster, _, width, _ = uniseg.FirstGraphemeCluster(b[i:], -1)
+			if m == WcWidth {
+				width = runewidth.StringWidth(string(cluster))
+			}
 
 			i += len(cluster)
 			curWidth += width

--- a/ansi/width.go
+++ b/ansi/width.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/charmbracelet/x/ansi/parser"
+	"github.com/mattn/go-runewidth"
 	"github.com/rivo/uniseg"
 )
 
@@ -62,7 +63,21 @@ func Strip(s string) string {
 // cells that the string will occupy when printed in a terminal. ANSI escape
 // codes are ignored and wide characters (such as East Asians and emojis) are
 // accounted for.
+// This treats the text as a sequence of grapheme clusters.
 func StringWidth(s string) int {
+	return stringWidth(GraphemeWidth, s)
+}
+
+// WcStringWidth returns the width of a string in cells. This is the number of
+// cells that the string will occupy when printed in a terminal. ANSI escape
+// codes are ignored and wide characters (such as East Asians and emojis) are
+// accounted for.
+// This treats the text as a sequence of wide characters and runes.
+func WcStringWidth(s string) int {
+	return stringWidth(WcWidth, s)
+}
+
+func stringWidth(m Method, s string) int {
 	if s == "" {
 		return 0
 	}
@@ -78,6 +93,9 @@ func StringWidth(s string) int {
 		if state == parser.Utf8State {
 			var w int
 			cluster, _, w, _ = uniseg.FirstGraphemeClusterInString(s[i:], -1)
+			if m == WcWidth {
+				w = runewidth.StringWidth(cluster)
+			}
 			width += w
 			i += len(cluster) - 1
 			pstate = parser.GroundState

--- a/ansi/width.go
+++ b/ansi/width.go
@@ -68,12 +68,12 @@ func StringWidth(s string) int {
 	return stringWidth(GraphemeWidth, s)
 }
 
-// WcStringWidth returns the width of a string in cells. This is the number of
+// StringWidthWc returns the width of a string in cells. This is the number of
 // cells that the string will occupy when printed in a terminal. ANSI escape
 // codes are ignored and wide characters (such as East Asians and emojis) are
 // accounted for.
 // This treats the text as a sequence of wide characters and runes.
-func WcStringWidth(s string) int {
+func StringWidthWc(s string) int {
 	return stringWidth(WcWidth, s)
 }
 

--- a/ansi/width_test.go
+++ b/ansi/width_test.go
@@ -59,7 +59,7 @@ func TestStringWidth(t *testing.T) {
 func TestWcStringWidth(t *testing.T) {
 	for i, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if width := WcStringWidth(c.input); width != c.wcwidth {
+			if width := StringWidthWc(c.input); width != c.wcwidth {
 				t.Errorf("test case %d failed: expected %d, got %d", i+1, c.wcwidth, width)
 			}
 		})

--- a/ansi/width_test.go
+++ b/ansi/width_test.go
@@ -9,29 +9,31 @@ var cases = []struct {
 	input    string
 	stripped string
 	width    int
+	wcwidth  int
 }{
-	{"empty", "", "", 0},
-	{"ascii", "hello", "hello", 5},
-	{"emoji", "👋", "👋", 2},
-	{"wideemoji", "🫧", "🫧", 2},
-	{"combining", "a\u0300", "à", 1},
-	{"control", "\x1b[31mhello\x1b[0m", "hello", 5},
-	{"csi8", "\x9b38;5;1mhello\x9bm", "hello", 5},
-	{"osc", "\x9d2;charmbracelet: ~/Source/bubbletea\x9c", "", 0},
-	{"controlemoji", "\x1b[31m👋\x1b[0m", "👋", 2},
-	{"oscwideemoji", "\x1b]2;title👨‍👩‍👦\x07", "", 0},
-	{"oscwideemoji", "\x1b[31m👨‍👩‍👦\x1b[m", "👨\u200d👩\u200d👦", 2},
-	{"multiemojicsi", "👨‍👩‍👦\x9b38;5;1mhello\x9bm", "👨‍👩‍👦hello", 7},
-	{"osc8eastasianlink", "\x9d8;id=1;https://example.com/\x9c打豆豆\x9d8;id=1;\x07", "打豆豆", 6},
-	{"dcsarabic", "\x1bP?123$pسلام\x1b\\اهلا", "اهلا", 4},
-	{"newline", "hello\nworld", "hello\nworld", 10},
-	{"tab", "hello\tworld", "hello\tworld", 10},
-	{"controlnewline", "\x1b[31mhello\x1b[0m\nworld", "hello\nworld", 10},
-	{"style", "\x1B[38;2;249;38;114mfoo", "foo", 3},
-	{"unicode", "\x1b[35m“box”\x1b[0m", "“box”", 5},
-	{"just_unicode", "Claire’s Boutique", "Claire’s Boutique", 17},
-	{"unclosed_ansi", "Hey, \x1b[7m\n猴", "Hey, \n猴", 7},
-	{"double_asian_runes", " 你\x1b[8m好.", " 你好.", 6},
+	{"empty", "", "", 0, 0},
+	{"ascii", "hello", "hello", 5, 5},
+	{"emoji", "👋", "👋", 2, 2},
+	{"wideemoji", "🫧", "🫧", 2, 2},
+	{"combining", "a\u0300", "à", 1, 1},
+	{"control", "\x1b[31mhello\x1b[0m", "hello", 5, 5},
+	{"csi8", "\x9b38;5;1mhello\x9bm", "hello", 5, 5},
+	{"osc", "\x9d2;charmbracelet: ~/Source/bubbletea\x9c", "", 0, 0},
+	{"controlemoji", "\x1b[31m👋\x1b[0m", "👋", 2, 2},
+	{"oscwideemoji", "\x1b]2;title👨‍👩‍👦\x07", "", 0, 0},
+	{"oscwideemoji", "\x1b[31m👨‍👩‍👦\x1b[m", "👨\u200d👩\u200d👦", 2, 2},
+	{"multiemojicsi", "👨‍👩‍👦\x9b38;5;1mhello\x9bm", "👨‍👩‍👦hello", 7, 7},
+	{"osc8eastasianlink", "\x9d8;id=1;https://example.com/\x9c打豆豆\x9d8;id=1;\x07", "打豆豆", 6, 6},
+	{"dcsarabic", "\x1bP?123$pسلام\x1b\\اهلا", "اهلا", 4, 4},
+	{"newline", "hello\nworld", "hello\nworld", 10, 10},
+	{"tab", "hello\tworld", "hello\tworld", 10, 10},
+	{"controlnewline", "\x1b[31mhello\x1b[0m\nworld", "hello\nworld", 10, 10},
+	{"style", "\x1B[38;2;249;38;114mfoo", "foo", 3, 3},
+	{"unicode", "\x1b[35m“box”\x1b[0m", "“box”", 5, 5},
+	{"just_unicode", "Claire’s Boutique", "Claire’s Boutique", 17, 17},
+	{"unclosed_ansi", "Hey, \x1b[7m\n猴", "Hey, \n猴", 7, 7},
+	{"double_asian_runes", " 你\x1b[8m好.", " 你好.", 6, 6},
+	{"flag", "🇸🇦", "🇸🇦", 2, 1},
 }
 
 func TestStrip(t *testing.T) {
@@ -49,6 +51,16 @@ func TestStringWidth(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			if width := StringWidth(c.input); width != c.width {
 				t.Errorf("test case %d failed: expected %d, got %d", i+1, c.width, width)
+			}
+		})
+	}
+}
+
+func TestWcStringWidth(t *testing.T) {
+	for i, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if width := WcStringWidth(c.input); width != c.wcwidth {
+				t.Errorf("test case %d failed: expected %d, got %d", i+1, c.wcwidth, width)
 			}
 		})
 	}

--- a/ansi/wrap.go
+++ b/ansi/wrap.go
@@ -6,6 +6,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/charmbracelet/x/ansi/parser"
+	"github.com/mattn/go-runewidth"
 	"github.com/rivo/uniseg"
 )
 
@@ -17,7 +18,22 @@ const nbsp = 0xA0
 // wide-characters in the string.
 // When preserveSpace is true, spaces at the beginning of a line will be
 // preserved.
+// This treats the text as a sequence of graphemes.
 func Hardwrap(s string, limit int, preserveSpace bool) string {
+	return hardwrap(GraphemeWidth, s, limit, preserveSpace)
+}
+
+// WcHardwrap wraps a string or a block of text to a given line length, breaking
+// word boundaries. This will preserve ANSI escape codes and will account for
+// wide-characters in the string.
+// When preserveSpace is true, spaces at the beginning of a line will be
+// preserved.
+// This treats the text as a sequence of wide characters and runes.
+func WcHardwrap(s string, limit int, preserveSpace bool) string {
+	return hardwrap(WcWidth, s, limit, preserveSpace)
+}
+
+func hardwrap(m Method, s string, limit int, preserveSpace bool) string {
 	if limit < 1 {
 		return s
 	}
@@ -42,6 +58,9 @@ func Hardwrap(s string, limit int, preserveSpace bool) string {
 		if state == parser.Utf8State {
 			var width int
 			cluster, _, width, _ = uniseg.FirstGraphemeCluster(b[i:], -1)
+			if m == WcWidth {
+				width = runewidth.StringWidth(string(cluster))
+			}
 			i += len(cluster)
 
 			if curWidth+width > limit {
@@ -108,7 +127,27 @@ func Hardwrap(s string, limit int, preserveSpace bool) string {
 // breakpoint.
 //
 // Note: breakpoints must be a string of 1-cell wide rune characters.
+//
+// This treats the text as a sequence of graphemes.
 func Wordwrap(s string, limit int, breakpoints string) string {
+	return wordwrap(GraphemeWidth, s, limit, breakpoints)
+}
+
+// WcWordwrap wraps a string or a block of text to a given line length, not
+// breaking word boundaries. This will preserve ANSI escape codes and will
+// account for wide-characters in the string.
+// The breakpoints string is a list of characters that are considered
+// breakpoints for word wrapping. A hyphen (-) is always considered a
+// breakpoint.
+//
+// Note: breakpoints must be a string of 1-cell wide rune characters.
+//
+// This treats the text as a sequence of wide characters and runes.
+func WcWordwrap(s string, limit int, breakpoints string) string {
+	return wordwrap(WcWidth, s, limit, breakpoints)
+}
+
+func wordwrap(m Method, s string, limit int, breakpoints string) string {
 	if limit < 1 {
 		return s
 	}
@@ -154,6 +193,9 @@ func Wordwrap(s string, limit int, breakpoints string) string {
 		if state == parser.Utf8State {
 			var width int
 			cluster, _, width, _ = uniseg.FirstGraphemeCluster(b[i:], -1)
+			if m == WcWidth {
+				width = runewidth.StringWidth(string(cluster))
+			}
 			i += len(cluster)
 
 			r, _ := utf8.DecodeRune(cluster)
@@ -236,7 +278,26 @@ func Wordwrap(s string, limit int, breakpoints string) string {
 // (-) is always considered a breakpoint.
 //
 // Note: breakpoints must be a string of 1-cell wide rune characters.
+//
+// This treats the text as a sequence of graphemes.
 func Wrap(s string, limit int, breakpoints string) string {
+	return wrap(GraphemeWidth, s, limit, breakpoints)
+}
+
+// WcWrap wraps a string or a block of text to a given line length, breaking word
+// boundaries if necessary. This will preserve ANSI escape codes and will
+// account for wide-characters in the string. The breakpoints string is a list
+// of characters that are considered breakpoints for word wrapping. A hyphen
+// (-) is always considered a breakpoint.
+//
+// Note: breakpoints must be a string of 1-cell wide rune characters.
+//
+// This treats the text as a sequence of wide characters and runes.
+func WcWrap(s string, limit int, breakpoints string) string {
+	return wrap(WcWidth, s, limit, breakpoints)
+}
+
+func wrap(m Method, s string, limit int, breakpoints string) string {
 	if limit < 1 {
 		return s
 	}
@@ -282,6 +343,9 @@ func Wrap(s string, limit int, breakpoints string) string {
 		if state == parser.Utf8State {
 			var width int
 			cluster, _, width, _ = uniseg.FirstGraphemeCluster(b[i:], -1)
+			if m == WcWidth {
+				width = runewidth.StringWidth(string(cluster))
+			}
 			i += len(cluster)
 
 			r, _ := utf8.DecodeRune(cluster)

--- a/ansi/wrap.go
+++ b/ansi/wrap.go
@@ -23,13 +23,13 @@ func Hardwrap(s string, limit int, preserveSpace bool) string {
 	return hardwrap(GraphemeWidth, s, limit, preserveSpace)
 }
 
-// WcHardwrap wraps a string or a block of text to a given line length, breaking
+// HardwrapWc wraps a string or a block of text to a given line length, breaking
 // word boundaries. This will preserve ANSI escape codes and will account for
 // wide-characters in the string.
 // When preserveSpace is true, spaces at the beginning of a line will be
 // preserved.
 // This treats the text as a sequence of wide characters and runes.
-func WcHardwrap(s string, limit int, preserveSpace bool) string {
+func HardwrapWc(s string, limit int, preserveSpace bool) string {
 	return hardwrap(WcWidth, s, limit, preserveSpace)
 }
 
@@ -133,7 +133,7 @@ func Wordwrap(s string, limit int, breakpoints string) string {
 	return wordwrap(GraphemeWidth, s, limit, breakpoints)
 }
 
-// WcWordwrap wraps a string or a block of text to a given line length, not
+// WordwrapWc wraps a string or a block of text to a given line length, not
 // breaking word boundaries. This will preserve ANSI escape codes and will
 // account for wide-characters in the string.
 // The breakpoints string is a list of characters that are considered
@@ -143,7 +143,7 @@ func Wordwrap(s string, limit int, breakpoints string) string {
 // Note: breakpoints must be a string of 1-cell wide rune characters.
 //
 // This treats the text as a sequence of wide characters and runes.
-func WcWordwrap(s string, limit int, breakpoints string) string {
+func WordwrapWc(s string, limit int, breakpoints string) string {
 	return wordwrap(WcWidth, s, limit, breakpoints)
 }
 
@@ -284,7 +284,7 @@ func Wrap(s string, limit int, breakpoints string) string {
 	return wrap(GraphemeWidth, s, limit, breakpoints)
 }
 
-// WcWrap wraps a string or a block of text to a given line length, breaking word
+// WrapWc wraps a string or a block of text to a given line length, breaking word
 // boundaries if necessary. This will preserve ANSI escape codes and will
 // account for wide-characters in the string. The breakpoints string is a list
 // of characters that are considered breakpoints for word wrapping. A hyphen
@@ -293,7 +293,7 @@ func Wrap(s string, limit int, breakpoints string) string {
 // Note: breakpoints must be a string of 1-cell wide rune characters.
 //
 // This treats the text as a sequence of wide characters and runes.
-func WcWrap(s string, limit int, breakpoints string) string {
+func WrapWc(s string, limit int, breakpoints string) string {
 	return wrap(WcWidth, s, limit, breakpoints)
 }
 


### PR DESCRIPTION
This commit introduces a new type, Method, that represents how the renderer should calculate the display width of cells. It adds helper methods to the Method type that allow users to use either WcWidth, which uses go-runewidth, or GraphemeWidth, which uses uniseg, to calculate the width of strings and text.

Methods like `ansi.StringWidth`, `ansi.Truncate`, `ansi.TruncateLeft`, and `ansi.Cut` now have variants that are aware of wide characters and runes. These new methods are suffixed with `Wc` and use go-runewidth to calculate the width of strings.

Related: https://github.com/charmbracelet/x/pull/217