### PR TITLE
teatest: fix race condition

### DIFF
--- a/exp/teatest/teatest.go
+++ b/exp/teatest/teatest.go
@@ -141,8 +141,8 @@ func NewTestModel(tb testing.TB, m tea.Model, options ...TestOption) *TestModel 
 		if err != nil {
 			tb.Fatalf("app failed: %s", err)
 		}
-		tm.doneCh <- true
 		tm.modelCh <- m
+		tm.doneCh <- true
 	}()
 	go func() {
 		<-interruptions

--- a/exp/teatest/v2/teatest.go
+++ b/exp/teatest/v2/teatest.go
@@ -139,8 +139,8 @@ func NewTestModel(tb testing.TB, m tea.Model, options ...TestOption) *TestModel 
 		if err != nil {
 			tb.Fatalf("app failed: %s", err)
 		}
-		tm.doneCh <- true
 		tm.modelCh <- m
+		tm.doneCh <- true
 	}()
 	go func() {
 		<-interruptions


### PR DESCRIPTION
I am running into a race condition where the final model would still be nil rather than the expected model even after the program completed the the done signal sent. This seems to fix it.

Send the final model ‘_before_’ sending the program is done signal, such that `FinalModel()` can correctly receive the final model from `modelCh` rather than returning the default `tm.model` which is null.

```go
func (tm *TestModel) FinalModel(tb testing.TB, opts ...FinalOpt) tea.Model {
	tm.waitDone(tb, opts)
	select {
	case m := <-tm.modelCh:
		tm.model = m
		return tm.model
	default:
		return tm.model
	}
}
```

Specifically, in the above code `tm.waitDone(tb, opts)` would wait for `doneCh` to receive true _before_ selecting on the `tm.modelCh` which might not receive the final model since it is being sent '_after_' the `doneCh` signal is sent. This fixes that ordering issue.


cc: @aymanbagabas 