### PR TITLE
feat: add WaitForMsg function

### DIFF
--- a/exp/teatest/app_test.go
+++ b/exp/teatest/app_test.go
@@ -60,7 +60,7 @@ func TestAppInteractive(t *testing.T) {
 		t.Fatalf("output does not match: expected %q", string(bts))
 	}
 
-	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+	teatest.WaitForOutput(t, tm.Output(), func(out []byte) bool {
 		return bytes.Contains(out, []byte("This program will exit in 7 seconds"))
 	}, teatest.WithDuration(5*time.Second), teatest.WithCheckInterval(time.Millisecond*10))
 

--- a/exp/teatest/msg_buffer.go
+++ b/exp/teatest/msg_buffer.go
@@ -1,0 +1,31 @@
+package teatest
+
+import (
+	"sync"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// msgBuffer stores messages for checking in WaitForMsg.
+type msgBuffer struct {
+	msgs []tea.Msg
+	mu   sync.Mutex
+}
+
+func (b *msgBuffer) append(msg tea.Msg) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.msgs = append(b.msgs, msg)
+}
+
+// forEach executes the given function for each message while holding the lock.
+func (b *msgBuffer) forEach(fn func(msg tea.Msg) bool) tea.Msg {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, msg := range b.msgs {
+		if fn(msg) {
+			return msg
+		}
+	}
+	return nil
+}

--- a/exp/teatest/msg_capture.go
+++ b/exp/teatest/msg_capture.go
@@ -1,0 +1,32 @@
+package teatest
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// msgCaptureModel wraps a model to capture messages.
+type msgCaptureModel struct {
+	model  tea.Model
+	buffer *msgBuffer
+}
+
+func (m msgCaptureModel) Init() tea.Cmd {
+	return m.model.Init()
+}
+
+func (m msgCaptureModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	m.buffer.append(msg)
+	model, cmd := m.model.Update(msg)
+	if wrappedModel, ok := model.(msgCaptureModel); ok {
+		return wrappedModel, cmd
+	}
+
+	return msgCaptureModel{
+		model:  model,
+		buffer: m.buffer,
+	}, cmd
+}
+
+func (m msgCaptureModel) View() string {
+	return m.model.View()
+}

--- a/exp/teatest/teatest.go
+++ b/exp/teatest/teatest.go
@@ -114,6 +114,8 @@ type TestModel struct {
 
 	done   sync.Once
 	doneCh chan bool
+
+	msgs *msgBuffer
 }
 
 // NewTestModel makes a new TestModel which can be used for tests.
@@ -123,11 +125,19 @@ func NewTestModel(tb testing.TB, m tea.Model, options ...TestOption) *TestModel 
 		out:     safe(bytes.NewBuffer(nil)),
 		modelCh: make(chan tea.Model, 1),
 		doneCh:  make(chan bool, 1),
+		msgs: &msgBuffer{
+			msgs: make([]tea.Msg, 0),
+		},
+	}
+
+	wrappedModel := msgCaptureModel{
+		model:  m,
+		buffer: tm.msgs,
 	}
 
 	//nolint: staticcheck
 	tm.program = tea.NewProgram(
-		m,
+		wrappedModel,
 		tea.WithInput(tm.in),
 		tea.WithOutput(tm.out),
 		tea.WithoutSignals(),

--- a/exp/teatest/teatest.go
+++ b/exp/teatest/teatest.go
@@ -63,22 +63,22 @@ func WithDuration(d time.Duration) WaitForOption {
 	}
 }
 
-// WaitFor keeps reading from r until the condition matches.
+// WaitForOutput keeps reading from r until the condition matches.
 // Default duration is 1s, default check interval is 50ms.
 // These defaults can be changed with WithDuration and WithCheckInterval.
-func WaitFor(
+func WaitForOutput(
 	tb testing.TB,
 	r io.Reader,
 	condition func(bts []byte) bool,
 	options ...WaitForOption,
 ) {
 	tb.Helper()
-	if err := doWaitFor(r, condition, options...); err != nil {
+	if err := doWaitForOutput(r, condition, options...); err != nil {
 		tb.Fatal(err)
 	}
 }
 
-func doWaitFor(r io.Reader, condition func(bts []byte) bool, options ...WaitForOption) error {
+func doWaitForOutput(r io.Reader, condition func(bts []byte) bool, options ...WaitForOption) error {
 	wf := WaitingForContext{
 		Duration:      time.Second,
 		CheckInterval: 50 * time.Millisecond, //nolint: mnd

--- a/exp/teatest/teatest_test.go
+++ b/exp/teatest/teatest_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestWaitForErrorReader(t *testing.T) {
-	err := doWaitFor(iotest.ErrReader(fmt.Errorf("fake")), func(bts []byte) bool {
+	err := doWaitForOutput(iotest.ErrReader(fmt.Errorf("fake")), func(bts []byte) bool {
 		return true
 	}, WithDuration(time.Millisecond), WithCheckInterval(10*time.Microsecond))
 	if err == nil {
@@ -23,7 +23,7 @@ func TestWaitForErrorReader(t *testing.T) {
 }
 
 func TestWaitForTimeout(t *testing.T) {
-	err := doWaitFor(strings.NewReader("nope"), func(bts []byte) bool {
+	err := doWaitForOutput(strings.NewReader("nope"), func(bts []byte) bool {
 		return false
 	}, WithDuration(time.Millisecond), WithCheckInterval(10*time.Microsecond))
 	if err == nil {


### PR DESCRIPTION
Closes #310. Please see the linked issue for more context on the goals of (and motivations for) this PR.
Duplicate of #311; I had some issues with GitHub account that deleted the forked repo :(

Changes:
- Rename existing `WaitFor` function to `WaitForOutput` to avoid confusion with the new, similarly named method.
- Add `msgbuffer` type. This is a simple mutex-protected slice of `tea.Msg`.
- Add `msgCaptureModel` type. Implements `tea.Model`. Contains a child `tea.Model` and a `msgBuffer`. Every `tea.Msg` is stored in the buffer before being sent to the child model.
- Changes to `NewTestModel` so that the provided model is now wrapped in a `msgCaptureModel`.
	- Perhaps this could be disabled by default an enabled with a `TestOption`.
- Add method `TestModel` `WaitForMsg` which takes a condition function and returns a `tea.Msg`. Much of the code for this was copied from the `WaitFor` function (now called `WaitForOutput`). At a set interval it will check the messages stored within the buffer and if any matches the provided condition function it will be returned.

Please note this is not a complete solution. Instead, this is intended to spark a discussion. I am happy to put in the required work to polish this off, but I want to make sure it is something that the Charm team wants in their repo before spending more time on it :)