### PR TITLE
feat(ansi): add FinalTerm shell integration sequences

### DIFF
--- a/ansi/finalterm.go
+++ b/ansi/finalterm.go
@@ -1,0 +1,67 @@
+package ansi
+
+import "strings"
+
+// FinalTerm returns an escape sequence that is used for shell integrations.
+// Originally, FinalTerm designed the protocol hence the name.
+//
+//	OSC 133 ; Ps ; Pm ST
+//	OSC 133 ; Ps ; Pm BEL
+//
+// See: https://iterm2.com/documentation-shell-integration.html
+func FinalTerm(pm ...string) string {
+	return "\x1b]133;" + strings.Join(pm, ";") + "\x07"
+}
+
+// FinalTermPrompt returns an escape sequence that is used for shell
+// integrations prompt marks. This is sent just before the start of the shell
+// prompt.
+//
+// This is an alias for FinalTerm("A").
+func FinalTermPrompt(pm ...string) string {
+	if len(pm) == 0 {
+		return FinalTerm("A")
+	}
+	return FinalTerm(append([]string{"A"}, pm...)...)
+}
+
+// FinalTermCmdStart returns an escape sequence that is used for shell
+// integrations command start marks. This is sent just after the end of the
+// shell prompt, before the user enters a command.
+//
+// This is an alias for FinalTerm("B").
+func FinalTermCmdStart(pm ...string) string {
+	if len(pm) == 0 {
+		return FinalTerm("B")
+	}
+	return FinalTerm(append([]string{"B"}, pm...)...)
+}
+
+// FinalTermCmdExecuted returns an escape sequence that is used for shell
+// integrations command executed marks. This is sent just before the start of
+// the command output.
+//
+// This is an alias for FinalTerm("C").
+func FinalTermCmdExecuted(pm ...string) string {
+	if len(pm) == 0 {
+		return FinalTerm("C")
+	}
+	return FinalTerm(append([]string{"C"}, pm...)...)
+}
+
+// FinalTermCmdFinished returns an escape sequence that is used for shell
+// integrations command finished marks.
+//
+// If the command was sent after
+// [FinalTermCmdStart], it indicates that the command was aborted. If the
+// command was sent after [FinalTermCmdExecuted], it indicates the end of the
+// command output. If neither was sent, [FinalTermCmdFinished] should be
+// ignored.
+//
+// This is an alias for FinalTerm("D").
+func FinalTermCmdFinished(pm ...string) string {
+	if len(pm) == 0 {
+		return FinalTerm("D")
+	}
+	return FinalTerm(append([]string{"D"}, pm...)...)
+}


### PR DESCRIPTION
This adds the FinalTerm shell integration sequences. These are used for shell integrations and are used to mark the start and end of the shell prompt, command execution, and command output.

See https://iterm2.com/documentation-shell-integration.html for more information.
Related: https://github.com/charmbracelet/sequin/issues/46