### PR TITLE
fix(input): windows: mouse mode flag

### DIFF
--- a/input/cancelreader_other.go
+++ b/input/cancelreader_other.go
@@ -9,6 +9,6 @@ import (
 	"github.com/muesli/cancelreader"
 )
 
-func newCancelreader(r io.Reader) (cancelreader.CancelReader, error) {
+func newCancelreader(r io.Reader, _ int) (cancelreader.CancelReader, error) {
 	return cancelreader.NewReader(r)
 }

--- a/input/driver.go
+++ b/input/driver.go
@@ -67,7 +67,7 @@ type Reader struct {
 //	}
 func NewReader(r io.Reader, termType string, flags int) (*Reader, error) {
 	d := new(Reader)
-	cr, err := newCancelreader(r)
+	cr, err := newCancelreader(r, flags)
 	if err != nil {
 		return nil, err
 	}

--- a/input/parse.go
+++ b/input/parse.go
@@ -83,6 +83,10 @@ const (
 	// Key definitions come from Terminfo, this flag is only useful when
 	// FlagTerminfo is not set.
 	FlagFKeys
+
+	// When this flag is set, the driver will enable mouse mode on Windows.
+	// This is only useful on Windows and has no effect on other platforms.
+	FlagMouseMode
 )
 
 // Parser is a parser for input escape sequences.


### PR DESCRIPTION
We need to enable mouse mode on Windows on demand. This is done by adding a new flag to the input driver and passing it to the cancelreader to enable mouse mode.

Related: https://github.com/charmbracelet/bubbletea/issues/1313