### PR TITLE
fix(cellbuf): wrap: properly handle formatted spaces

### DIFF
--- a/cellbuf/cell.go
+++ b/cellbuf/cell.go
@@ -154,6 +154,11 @@ const (
 	ResetAttr AttrMask = 0
 )
 
+// Contains returns whether the attribute mask contains the attribute.
+func (a AttrMask) Contains(attr AttrMask) bool {
+	return a&attr == attr
+}
+
 // UnderlineStyle is the style of underline to use for text.
 type UnderlineStyle = ansi.UnderlineStyle
 

--- a/cellbuf/wrap.go
+++ b/cellbuf/wrap.go
@@ -39,6 +39,11 @@ func Wrap(s string, limit int, breakpoints string) string {
 		wordLen         int
 	)
 
+	hasBlankStyle := func() bool {
+		// Only follow reverse attribute, bg color and underline style
+		return !style.Attrs.Contains(ReverseAttr) && style.Bg == nil && style.UlStyle == NoUnderline
+	}
+
 	addSpace := func() {
 		curWidth += space.Len()
 		buf.Write(space.Bytes())
@@ -114,7 +119,7 @@ func Wrap(s string, limit int, breakpoints string) string {
 			if len(seq) == 1 {
 				// ASCII
 				r, _ := utf8.DecodeRuneInString(seq)
-				if unicode.IsSpace(r) {
+				if unicode.IsSpace(r) && hasBlankStyle() {
 					addWord()
 					space.WriteRune(r)
 					break

--- a/cellbuf/wrap.go
+++ b/cellbuf/wrap.go
@@ -8,6 +8,8 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
+const nbsp = '\u00a0'
+
 // Wrap returns a string that is wrapped to the specified limit applying any
 // ANSI escape sequences in the string. It tries to wrap the string at word
 // boundaries, but will break words if necessary.
@@ -119,7 +121,7 @@ func Wrap(s string, limit int, breakpoints string) string {
 			if len(seq) == 1 {
 				// ASCII
 				r, _ := utf8.DecodeRuneInString(seq)
-				if unicode.IsSpace(r) && hasBlankStyle() {
+				if r != nbsp && unicode.IsSpace(r) && hasBlankStyle() {
 					addWord()
 					space.WriteRune(r)
 					break

--- a/cellbuf/wrap_test.go
+++ b/cellbuf/wrap_test.go
@@ -123,6 +123,12 @@ var wrapCases = []struct {
 	{"osc8_wrap", "สวัสดีสวัสดี\x1b]8;;https://example.com\x1b\\ สวัสดีสวัสดี\x1b]8;;\x1b\\", "สวัสดีสวัสดี\x1b]8;;https://example.com\x1b\\\x1b]8;;\x07\n\x1b]8;;https://example.com\x07สวัสดีสวัสดี\x1b]8;;\x1b\\", 8},
 	{"tab", "foo\tbar", "foo\nbar", 3},
 	{"wrapped styles example", "", "", 10},
+	{
+		name:     "punctuation after formatted word with space",
+		input:    "\x1b[38;5;203;48;5;236m arm64 \x1b[0m, \x1b[38;5;203;48;5;236m amd64 \x1b[0m, \x1b[38;5;203;48;5;236m i386 \x1b[0m",
+		expected: "\x1b[38;5;203;48;5;236m arm64 \x1b[0m,\n\x1b[38;5;203;48;5;236m amd64 \x1b[0m, \x1b[38;5;203;48;5;236m i386 \x1b[0m",
+		width:    15,
+	},
 }
 
 func TestWrap(t *testing.T) {
@@ -130,7 +136,7 @@ func TestWrap(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			output := Wrap(tc.input, tc.width, "")
 			if output != tc.expected {
-				t.Errorf("case %d, input %q, expected %q, got %q", i+1, tc.input, tc.expected, output)
+				t.Errorf("case %d, input:\n%q\nexpected:\n%q\n%s\n\ngot:\n%q\n%s", i+1, tc.input, tc.expected, tc.expected, output, output)
 			}
 		})
 	}


### PR DESCRIPTION
This will treat formatted styled spaces as word characters. We need this because for example a space with a background shouldn't be truncated by the wrap.