### PR TITLE
docs(cellbuf): add usage example to cellbuf.Wrap

### DIFF
--- a/cellbuf/wrap_test.go
+++ b/cellbuf/wrap_test.go
@@ -2,6 +2,7 @@ package cellbuf
 
 import (
 	"testing"
+	"fmt"
 )
 
 var wrapCases = []struct {
@@ -140,4 +141,12 @@ func TestWrap(t *testing.T) {
 			}
 		})
 	}
+}
+
+func ExampleWrap() {
+	fmt.Println(Wrap("The quick brown fox jumped over the lazy dog.", 20, ""))
+	// Output:
+	// The quick brown fox
+	// jumped over the lazy
+	// dog.
 }


### PR DESCRIPTION
optional, but I thought this might be helpful to new users since we're using it more widely across projects now

![image](https://github.com/user-attachments/assets/ee071ce3-5642-44e8-9cbd-987b2e98e168)
