### PR TITLE
feat(input): add Keystroke to return the keystroke representation of …

### DIFF
--- a/input/driver.go
+++ b/input/driver.go
@@ -19,7 +19,7 @@ type Logger interface {
 // the last mouse button state and window size changes to determine which mouse
 // buttons were released and to prevent multiple size events from firing.
 //
-//nolint
+//nolint:all
 type win32InputState struct {
 	ansiBuf                    [256]byte
 	ansiIdx                    int
@@ -47,7 +47,7 @@ type Reader struct {
 
 	// keyState keeps track of the current Windows Console API key events state.
 	// It is used to decode ANSI escape sequences and utf16 sequences.
-	keyState win32InputState //nolint
+	keyState win32InputState //nolint:all
 
 	parser Parser
 	logger Logger

--- a/input/key.go
+++ b/input/key.go
@@ -311,10 +311,22 @@ type Key struct {
 	IsRepeat bool
 }
 
-// String implements [fmt.Stringer] and is used to convert a key to a string.
-// While less type safe than looking at the individual fields, it will usually
-// be more convenient and readable to use this method when matching against
-// keys.
+// String implements [fmt.Stringer] and is quite useful for matching key
+// events. It will return the textual representation of the [Key] if there is
+// one, otherwise, it will fallback to [Key.Keystroke].
+//
+// For example, you'll always get "?" and instead of "shift+/" on a US ANSI
+// keyboard.
+func (k Key) String() string {
+	if len(k.Text) > 0 {
+		return k.Text
+	}
+	return k.Keystroke()
+}
+
+// Keystroke returns the keystroke representation of the [Key]. While less type
+// safe than looking at the individual fields, it will usually be more
+// convenient and readable to use this method when matching against keys.
 //
 // Note that modifier keys are always printed in the following order:
 //   - ctrl
@@ -326,7 +338,7 @@ type Key struct {
 //
 // For example, you'll always see "ctrl+shift+alt+a" and never
 // "shift+ctrl+alt+a".
-func (k Key) String() string {
+func (k Key) Keystroke() string {
 	var sb strings.Builder
 	if k.Mod.Contains(ModCtrl) && k.Code != KeyLeftCtrl && k.Code != KeyRightCtrl {
 		sb.WriteString("ctrl+")

--- a/input/key_test.go
+++ b/input/key_test.go
@@ -25,9 +25,9 @@ var sequences = buildKeysTable(FlagTerminfo, "dumb")
 
 func TestKeyString(t *testing.T) {
 	t.Run("alt+space", func(t *testing.T) {
-		k := KeyPressEvent{Code: KeySpace, Text: " ", Mod: ModAlt}
+		k := KeyPressEvent{Code: KeySpace, Mod: ModAlt}
 		if got := k.String(); got != "alt+space" {
-			t.Fatalf(`expected a "alt+space ", got %q`, got)
+			t.Fatalf(`expected a "alt+space", got %q`, got)
 		}
 	})
 


### PR DESCRIPTION
…the key

This makes `Key.String()`  return the textual representation of the key if there is one, otherwise, it will fallback to `Key.Keystroke()`.
