### PR TITLE
feat(exp/slice): add `slice.Last` helper func

### DIFF
--- a/exp/slice/slice.go
+++ b/exp/slice/slice.go
@@ -22,14 +22,14 @@ func Take[A any](slice []A, n int) []A {
 	return slice[:n]
 }
 
-// Last returns the last element of a slice. If the slice is empty, it
-// returns the zero value.
-func Last[T any](list []T) T {
+// Last returns the last element of a slice and true. If the slice is empty, it
+// returns the zero value and false.
+func Last[T any](list []T) (T, bool) {
 	if len(list) == 0 {
 		var zero T
-		return zero
+		return zero, false
 	}
-	return list[len(list)-1]
+	return list[len(list)-1], true
 }
 
 // Uniq returns a new slice with all duplicates removed.

--- a/exp/slice/slice.go
+++ b/exp/slice/slice.go
@@ -1,3 +1,4 @@
+// Package slice provides utility functions for working with slices in Go.
 package slice
 
 // GroupBy groups a slice of items by a key function.

--- a/exp/slice/slice.go
+++ b/exp/slice/slice.go
@@ -21,6 +21,16 @@ func Take[A any](slice []A, n int) []A {
 	return slice[:n]
 }
 
+// Last returns the last element of a slice. If the slice is empty, it
+// returns the zero value.
+func Last[T any](list []T) T {
+	if len(list) == 0 {
+		var zero T
+		return zero
+	}
+	return list[len(list)-1]
+}
+
 // Uniq returns a new slice with all duplicates removed.
 func Uniq[T comparable](list []T) []T {
 	seen := make(map[T]struct{}, len(list))

--- a/exp/slice/slice_test.go
+++ b/exp/slice/slice_test.go
@@ -69,26 +69,34 @@ func TestTake(t *testing.T) {
 func TestLast(t *testing.T) {
 	for i, tc := range []struct {
 		input    []int
+		ok       bool
 		expected int
 	}{
 		{
 			input:    []int{1, 2, 3, 4, 5},
+			ok:       true,
 			expected: 5,
 		},
 		{
 			input:    []int{1, 2, 3},
+			ok:       true,
 			expected: 3,
 		},
 		{
 			input:    []int{1},
+			ok:       true,
 			expected: 1,
 		},
 		{
 			input:    []int{},
+			ok:       false,
 			expected: 0,
 		},
 	} {
-		actual := Last(tc.input)
+		actual, ok := Last(tc.input)
+		if ok != tc.ok {
+			t.Errorf("Test %d: Expected ok %v, got %v", i, tc.ok, ok)
+		}
 		if actual != tc.expected {
 			t.Errorf("Test %d: Expected %v, got %v", i, tc.expected, actual)
 		}

--- a/exp/slice/slice_test.go
+++ b/exp/slice/slice_test.go
@@ -66,6 +66,35 @@ func TestTake(t *testing.T) {
 	}
 }
 
+func TestLast(t *testing.T) {
+	for i, tc := range []struct {
+		input    []int
+		expected int
+	}{
+		{
+			input:    []int{1, 2, 3, 4, 5},
+			expected: 5,
+		},
+		{
+			input:    []int{1, 2, 3},
+			expected: 3,
+		},
+		{
+			input:    []int{1},
+			expected: 1,
+		},
+		{
+			input:    []int{},
+			expected: 0,
+		},
+	} {
+		actual := Last(tc.input)
+		if actual != tc.expected {
+			t.Errorf("Test %d: Expected %v, got %v", i, tc.expected, actual)
+		}
+	}
+}
+
 func TestUniq(t *testing.T) {
 	for i, tc := range []struct {
 		input    []int


### PR DESCRIPTION
Just a small convenience function to have clearer code.

```go
last := obj.List[len(obj.List)-1]
```

Becomes:

```go
last := slice.Last(obj.List)
```