### PR TITLE
perf(ansi): improve performance of wrap space handling

### DIFF
--- a/ansi/wrap.go
+++ b/ansi/wrap.go
@@ -303,20 +303,22 @@ func wrap(m Method, s string, limit int, breakpoints string) string {
 	}
 
 	var (
-		cluster  []byte
-		buf      bytes.Buffer
-		word     bytes.Buffer
-		space    bytes.Buffer
-		curWidth int                  // written width of the line
-		wordLen  int                  // word buffer len without ANSI escape codes
-		pstate   = parser.GroundState // initial state
-		b        = []byte(s)
+		cluster    []byte
+		buf        bytes.Buffer
+		word       bytes.Buffer
+		space      bytes.Buffer
+		spaceWidth int                  // width of the space buffer
+		curWidth   int                  // written width of the line
+		wordLen    int                  // word buffer len without ANSI escape codes
+		pstate     = parser.GroundState // initial state
+		b          = []byte(s)
 	)
 
 	addSpace := func() {
-		curWidth += StringWidth(space.String())
+		curWidth += spaceWidth
 		buf.Write(space.Bytes())
 		space.Reset()
+		spaceWidth = 0
 	}
 
 	addWord := func() {
@@ -335,6 +337,7 @@ func wrap(m Method, s string, limit int, breakpoints string) string {
 		buf.WriteByte('\n')
 		curWidth = 0
 		space.Reset()
+		spaceWidth = 0
 	}
 
 	i := 0
@@ -353,6 +356,7 @@ func wrap(m Method, s string, limit int, breakpoints string) string {
 			case r != utf8.RuneError && unicode.IsSpace(r) && r != nbsp: // nbsp is a non-breaking space
 				addWord()
 				space.WriteRune(r)
+				spaceWidth += width
 			case bytes.ContainsAny(cluster, breakpoints):
 				addSpace()
 				if curWidth+wordLen+width > limit {
@@ -372,7 +376,7 @@ func wrap(m Method, s string, limit int, breakpoints string) string {
 				word.Write(cluster)
 				wordLen += width
 
-				if curWidth+wordLen+StringWidth(space.String()) > limit {
+				if curWidth+wordLen+spaceWidth > limit {
 					addNewline()
 				}
 			}
@@ -386,13 +390,14 @@ func wrap(m Method, s string, limit int, breakpoints string) string {
 			switch r := rune(b[i]); {
 			case r == '\n':
 				if wordLen == 0 {
-					if curWidth+StringWidth(space.String()) > limit {
+					if curWidth+spaceWidth > limit {
 						curWidth = 0
 					} else {
 						// preserve whitespaces
 						buf.Write(space.Bytes())
 					}
 					space.Reset()
+					spaceWidth = 0
 				}
 
 				addWord()
@@ -400,6 +405,7 @@ func wrap(m Method, s string, limit int, breakpoints string) string {
 			case unicode.IsSpace(r):
 				addWord()
 				space.WriteRune(r)
+				spaceWidth++
 			case r == '-':
 				fallthrough
 			case runeContainsAny(r, breakpoints):
@@ -426,7 +432,7 @@ func wrap(m Method, s string, limit int, breakpoints string) string {
 					addWord()
 				}
 
-				if curWidth+wordLen+StringWidth(space.String()) > limit {
+				if curWidth+wordLen+spaceWidth > limit {
 					addNewline()
 				}
 			}
@@ -443,13 +449,14 @@ func wrap(m Method, s string, limit int, breakpoints string) string {
 	}
 
 	if wordLen == 0 {
-		if curWidth+StringWidth(space.String()) > limit {
+		if curWidth+spaceWidth > limit {
 			curWidth = 0
 		} else {
 			// preserve whitespaces
 			buf.Write(space.Bytes())
 		}
 		space.Reset()
+		spaceWidth = 0
 	}
 
 	addWord()


### PR DESCRIPTION
Keep track of the width of spaces in the wrap function instead of calculating it each time a space is added. This removes the need to call `StringWidth` for spaces, which can be more expensive for large amounts of text.

Fixes: 402b57aeba7d (fix(ansi): fix ansi.Wrap for multi byte spaces (#469))
Fixes: https://github.com/charmbracelet/x/pull/469

CC/ @lazysegtree