### PR TITLE
feat(toner): add initial implementation

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-alpha.2.0.20250125233033-58a153eb00e6
 	github.com/charmbracelet/x/ansi v0.9.2
 	github.com/charmbracelet/x/cellbuf v0.0.13
+	github.com/charmbracelet/x/exp/charmtone v0.0.0-20250602192518-9e722df69bbb
+	github.com/charmbracelet/x/exp/toner v0.0.0-20250602202920-5fecc56e9a94
 	github.com/charmbracelet/x/input v0.3.4
 	github.com/charmbracelet/x/mosaic v0.0.0-20250313150240-c09addb0e197
 	github.com/creack/pty v1.1.24

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -12,6 +12,10 @@ github.com/charmbracelet/x/ansi v0.9.2 h1:92AGsQmNTRMzuzHEYfCdjQeUzTrgE1vfO5/7fE
 github.com/charmbracelet/x/ansi v0.9.2/go.mod h1:3RQDQ6lDnROptfpWuUVIUG64bD2g2BgntdxH0Ya5TeE=
 github.com/charmbracelet/x/cellbuf v0.0.13 h1:/KBBKHuVRbq1lYx5BzEHBAFBP8VcQzJejZ/IA3iR28k=
 github.com/charmbracelet/x/cellbuf v0.0.13/go.mod h1:xe0nKWGd3eJgtqZRaN9RjMtK7xUYchjzPr7q6kcvCCs=
+github.com/charmbracelet/x/exp/charmtone v0.0.0-20250602192518-9e722df69bbb h1:oTM8tZxV7FY0ehvYjFuICouuhzE08UZYNqUIp/lDQdY=
+github.com/charmbracelet/x/exp/charmtone v0.0.0-20250602192518-9e722df69bbb/go.mod h1:T9jr8CzFpjhFVHjNjKwbAD7KwBNyFnj2pntAO7F2zw0=
+github.com/charmbracelet/x/exp/toner v0.0.0-20250602202920-5fecc56e9a94 h1:fTfXJX8blzJXrRs+O7CFug2m6Ohx3B8fejzFL6LQ4fk=
+github.com/charmbracelet/x/exp/toner v0.0.0-20250602202920-5fecc56e9a94/go.mod h1:3EBVyRnlgADiAU0TJVgIpn3kl/gMg8Jc9s+V44LzRHw=
 github.com/charmbracelet/x/input v0.3.4 h1:Mujmnv/4DaitU0p+kIsrlfZl/UlmeLKw1wAP3e1fMN0=
 github.com/charmbracelet/x/input v0.3.4/go.mod h1:JI8RcvdZWQIhn09VzeK3hdp4lTz7+yhiEdpEQtZN+2c=
 github.com/charmbracelet/x/mosaic v0.0.0-20250313150240-c09addb0e197 h1:QfivHUhUC9M9mRy8w9Zigbs96dNjfZZPciVrTnLDbBw=

--- a/examples/toner/main.go
+++ b/examples/toner/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+
+	"github.com/charmbracelet/x/exp/toner"
+)
+
+func main() {
+	bts, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatalf("failed to read from stdin: %v", err)
+	}
+
+	w := toner.Writer{Writer: os.Stdout}
+	if _, err := w.Write(bts); err != nil {
+		log.Fatalf("failed to write to stdout: %v", err)
+	}
+}

--- a/exp/toner/go.mod
+++ b/exp/toner/go.mod
@@ -1,0 +1,14 @@
+module github.com/charmbracelet/x/exp/toner
+
+go 1.23.0
+
+require (
+	github.com/charmbracelet/x/ansi v0.8.0
+	github.com/charmbracelet/x/exp/charmtone v0.0.0-20250602192518-9e722df69bbb
+)
+
+require (
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
+)

--- a/exp/toner/go.sum
+++ b/exp/toner/go.sum
@@ -1,0 +1,11 @@
+github.com/charmbracelet/x/ansi v0.8.0 h1:9GTq3xq9caJW8ZrBTe0LIe2fvfLR/bYXKTx2llXn7xE=
+github.com/charmbracelet/x/ansi v0.8.0/go.mod h1:wdYl/ONOLHLIVmQaxbIYEC/cRKOQyjTkowiI4blgS9Q=
+github.com/charmbracelet/x/exp/charmtone v0.0.0-20250602192518-9e722df69bbb h1:oTM8tZxV7FY0ehvYjFuICouuhzE08UZYNqUIp/lDQdY=
+github.com/charmbracelet/x/exp/charmtone v0.0.0-20250602192518-9e722df69bbb/go.mod h1:T9jr8CzFpjhFVHjNjKwbAD7KwBNyFnj2pntAO7F2zw0=
+github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
+github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/exp/toner/toner.go
+++ b/exp/toner/toner.go
@@ -1,0 +1,93 @@
+package toner
+
+import (
+	"bytes"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/exp/charmtone"
+)
+
+// Strings returns a colorized string representation of the input byte slice or
+// string.
+func Strings(s string) string {
+	return colorize(s)
+}
+
+// Bytes returns a colorized byte slice representation of the input byte slice.
+func Bytes(b []byte) []byte {
+	return colorize(b)
+}
+
+// Writer encapsulates a [io.Writer] that colorizes the output using charm tones.
+type Writer struct {
+	io.Writer
+}
+
+// Write writes the colorized output to the underlying writer.
+func (w Writer) Write(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	colored := colorize(p)
+	n, err = w.Writer.Write(colored)
+	return n, err
+}
+
+// WriteString writes the colorized output of the input string to the underlying writer.
+func (w Writer) WriteString(s string) (n int, err error) {
+	if len(s) == 0 {
+		return 0, nil
+	}
+
+	colored := colorize(s)
+	n, err = io.WriteString(w.Writer, colored)
+	return n, err
+}
+
+const (
+	startTone = charmtone.Cumin
+	endTone   = charmtone.Zest
+)
+
+func colorize[T []byte | string](b T) T {
+	var buf bytes.Buffer
+
+	p := ansi.NewParser()
+
+	var state byte
+	for len(b) > 0 {
+		seq, w, n, newState := ansi.DecodeSequence(b, state, p)
+		cmd := p.Command()
+
+		var st ansi.Style
+		var s string
+		if cmd == 0 && w > 0 {
+			s = string(seq)
+		} else {
+			st = st.ForegroundColor(charmtone.Key(cmd % int(endTone)))
+			s = string(seq)
+		}
+
+		s = strconv.Quote(s)
+		s = strings.TrimPrefix(s, "\"")
+		s = strings.TrimSuffix(s, "\"")
+		if len(st) > 0 {
+			s = st.Styled(s)
+		}
+		buf.WriteString(s)
+
+		b = b[n:]
+		state = newState
+	}
+
+	switch any(b).(type) {
+	case []byte:
+		return T(buf.Bytes())
+	default:
+		return T(buf.String())
+	}
+}


### PR DESCRIPTION
This is a small package that provides a way to colorize escape sequences from strings and byte slices using charm tones.

```go
ansiSequences := "\033[31mHello, World!\033[0m"
colored := toner.Strings(ansiSequences)
fmt.Println(colored) // Outputs colorizes the sequences using charm tones.
```

<img width="535" alt="image" src="https://github.com/user-attachments/assets/2214c39e-7868-45ca-81aa-64258aad0f97" />
