### PR TITLE
feat(conpty): expose underlying conpty file descriptors 

### DIFF
--- a/conpty/conpty_windows.go
+++ b/conpty/conpty_windows.go
@@ -14,12 +14,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// Default size.
-const (
-	DefaultWidth  = 80
-	DefaultHeight = 25
-)
-
 // ConPty represents a Windows Console Pseudo-terminal.
 // https://learn.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session#preparing-the-communication-channels
 type ConPty struct {

--- a/conpty/doc.go
+++ b/conpty/doc.go
@@ -8,3 +8,9 @@ import "errors"
 
 // ErrUnsupported is returned when the current platform is not supported.
 var ErrUnsupported = errors.New("conpty: unsupported platform")
+
+// Default size.
+const (
+	DefaultWidth  = 80
+	DefaultHeight = 25
+)


### PR DESCRIPTION
This simply split New into two functions and exposes
the ConPty underlying I/O FDs so that they can be
used as I/O passed to a different process.

This also adds a new helper CreatePipes that simply creates
connected I/O pipe FDs.