### PR TITLE
fix(charmtone): add missing `Barbeque` to `Keys()`

### DIFF
--- a/exp/charmtone/charmtone.go
+++ b/exp/charmtone/charmtone.go
@@ -267,6 +267,7 @@ func Keys() []Key {
 		Citron,
 		Zest,
 		Pepper,
+		Barbeque,
 		Charcoal,
 		Iron,
 		Oyster,


### PR DESCRIPTION
This fixes `examples/charmtone` that panics with this:

    panic: runtime error: index out of range [57] with length 57

    goroutine 1 [running]:
    main.main()
    	/Users/andrey/Developer/charm/x/examples/charmtone/main.go:123 +0x2114
