### PR TITLE
chore(exp/charmtone): revert recent changes to zinc and guac

### DIFF
--- a/examples/charmtone/main.go
+++ b/examples/charmtone/main.go
@@ -163,12 +163,16 @@ func main() {
 		s := subdued.
 			Foreground(charmtone.Squid)
 
+		// Gradient:
+		// Hazy -> Blush, Bok -> Zest
 		left := blendKeys(halfWidth, charmtone.Hazy, charmtone.Blush)
 		left += "\n" + block.Render(s.Render("Hazy")+rightArrowMark.String()+s.Render("Blush"))
 		right := blendKeys(halfWidth, charmtone.Bok, charmtone.Zest)
 		right += "\n" + block.Render(s.Render("Bok")+rightArrowMark.String()+s.Render("Zest"))
 		fmt.Fprint(&grads, "\n", lipgloss.JoinHorizontal(lipgloss.Top, gap, left, right))
 
+		// Gradient:
+		// Uni -> Coral -> Tuna -> Violet -> Malibu -> Turtle
 		block = block.Width(fullWidth)
 		buf := strings.Builder{}
 		fmt.Fprint(&buf, blendKeys(fullWidth, charmtone.Uni,

--- a/exp/charmtone/charmtone.go
+++ b/exp/charmtone/charmtone.go
@@ -74,6 +74,10 @@ const (
 	Ash
 	Salt
 	Butter
+
+	// Provisional.
+	NeueGuac
+	NeueZinc
 )
 
 // RGBA returns the red, green, blue, and alpha values of the color. It
@@ -148,6 +152,10 @@ func (k Key) String() string {
 		Salt:     "Salt",
 		Ash:      "Ash",
 		Butter:   "Butter",
+
+		// Provisional.
+		NeueGuac: "Neue Guac",
+		NeueZinc: "Neue Zinc",
 	}[k]
 }
 
@@ -193,10 +201,10 @@ func (k Key) Hex() string {
 		Damson:   "#007AB8",
 		Malibu:   "#00A4FF",
 		Sardine:  "#4FBEFE",
-		Zinc:     "#0e9996",
+		Zinc:     "#10B1AE",
 		Turtle:   "#0ADCD9",
 		Lichen:   "#5CDFEA",
-		Guac:     "#00b875",
+		Guac:     "#12C78F",
 		Julep:    "#00FFB2",
 		Bok:      "#68FFD6",
 		Mustard:  "#F5EF34",
@@ -212,6 +220,10 @@ func (k Key) Hex() string {
 		Ash:      "#DFDBDD",
 		Salt:     "#F1EFEF",
 		Butter:   "#FFFAF1",
+
+		// Provisional.
+		NeueGuac: "#00b875",
+		NeueZinc: "#0e9996",
 	}[k]
 }
 


### PR DESCRIPTION
Changed values are temporarily stored as NeueZinc and NeueGuac for testing.
