### PR TITLE
fix(input): string terminated input sequence events

### DIFF
--- a/input/driver_windows_test.go
+++ b/input/driver_windows_test.go
@@ -81,6 +81,12 @@ func TestWindowsInputEvents(t *testing.T) {
 			sequence: true,
 		},
 		{
+			name:     "st terminated background color response",
+			events:   encodeSequence("\x1b]11;rgb:ffff/ffff/ffff\x1b\\"),
+			expected: []Event{BackgroundColorEvent{Color: color.RGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}}},
+			sequence: true,
+		},
+		{
 			name: "simple mouse event",
 			events: []xwindows.InputRecord{
 				encodeMouseEvent(xwindows.MouseEventRecord{


### PR DESCRIPTION
When parsing input events on Windows, ensure that string terminated input sequences are handled correctly.

Fixes: https://github.com/charmbracelet/bubbletea/issues/1440
Fixes: https://github.com/charmbracelet/bubbletea/issues/1406
