### PR TITLE
feat: move gradient generator to its own package

### DIFF
--- a/examples/charmtone/main.go
+++ b/examples/charmtone/main.go
@@ -205,9 +205,9 @@ func main() {
 	}
 }
 
-func blendKeys(width int, keys ...charmtone.Key) string {
+func blendKeys(size int, keys ...charmtone.Key) string {
 	var w strings.Builder
-	for _, c := range charmtone.BlendColors(width, keys...) {
+	for _, c := range charmtone.Blend(size, keys...) {
 		fmt.Fprint(&w, lipgloss.NewStyle().Background(c).Render(" "))
 	}
 	return w.String()

--- a/exp/charmtone/charmtone.go
+++ b/exp/charmtone/charmtone.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	"slices"
 
+	expcolor "github.com/charmbracelet/x/exp/color"
 	"github.com/lucasb-eyer/go-colorful"
 )
 
@@ -357,52 +358,12 @@ func (k Key) IsTertiary() bool {
 	}, k)
 }
 
-// BlendColors returns a slice of colors blended between the given keys.
-// Blending is done as Hcl to stay in gamut.
-func BlendColors(size int, keys ...Key) []color.Color {
-	if len(keys) < 2 {
-		return nil
-	}
-
-	stops := make([]colorful.Color, len(keys))
+// Blend returns a slice of colors blended between the given Keys. Blending is
+// done as Hcl to stay in gamut.
+func Blend(size int, keys ...Key) []color.Color {
+	colors := make([]color.Color, len(keys))
 	for i, k := range keys {
-		stops[i], _ = colorful.Hex(k.Hex())
+		colors[i] = color.Color(k)
 	}
-
-	numSegments := len(stops) - 1
-	if numSegments == 0 {
-		return nil
-	}
-	blended := make([]color.Color, 0, size)
-
-	// Calculate how many colors each segment should have.
-	segmentSizes := make([]int, numSegments)
-	baseSize := size / numSegments
-	remainder := size % numSegments
-
-	// Distribute the remainder across segments.
-	for i := range numSegments {
-		segmentSizes[i] = baseSize
-		if i < remainder {
-			segmentSizes[i]++
-		}
-	}
-
-	// Generate colors for each segment.
-	for i := range numSegments {
-		c1 := stops[i]
-		c2 := stops[i+1]
-		segmentSize := segmentSizes[i]
-
-		for j := range segmentSize {
-			if segmentSize == 0 {
-				continue
-			}
-			t := float64(j) / float64(segmentSize)
-			c := c1.BlendHcl(c2, t)
-			blended = append(blended, c)
-		}
-	}
-
-	return blended
+	return expcolor.Blend(size, colors...)
 }

--- a/exp/color/blend.go
+++ b/exp/color/blend.go
@@ -24,19 +24,19 @@ import (
 //
 //	lipgloss.Println(b.String())
 func Blend(size int, points ...color.Color) []color.Color {
-	if len(points) < 2 {
+	if size <= 0 || len(points) < 2 {
 		return nil
+	}
+	if size == 1 {
+		return []color.Color{points[0]}
 	}
 
 	stops := make([]colorful.Color, len(points))
-	for i, k := range points {
-		stops[i], _ = colorful.MakeColor(k)
+	for i, c := range points {
+		stops[i], _ = colorful.MakeColor(c)
 	}
 
 	numSegments := len(stops) - 1
-	if numSegments == 0 {
-		return nil
-	}
 	blended := make([]color.Color, 0, size)
 
 	// Calculate how many colors each segment should have.
@@ -59,9 +59,6 @@ func Blend(size int, points ...color.Color) []color.Color {
 		segmentSize := segmentSizes[i]
 
 		for j := range segmentSize {
-			if segmentSize == 0 {
-				continue
-			}
 			t := float64(j) / float64(segmentSize)
 			c := c1.BlendHcl(c2, t)
 			blended = append(blended, c)

--- a/exp/color/blend.go
+++ b/exp/color/blend.go
@@ -1,0 +1,72 @@
+// Package color contains utilities for working with colors.
+package color
+
+import (
+	"image/color"
+
+	"github.com/lucasb-eyer/go-colorful"
+)
+
+// Blend returns a slice of colors blended between the given
+// colors. Blending is done as Hcl to stay in gamut.
+//
+// Example:
+//
+//	red := color.RGBA{R: 0xff, G: 0x00, B: 0x00, A: 0xff}
+//	blue := color.RGBA{R: 0x00, G: 0x00, B: 0xff, A: 0xff}
+//
+//	blend := Blend(10, red, blue)
+//	var b strings.Builder
+//
+//	for _, c := range blend {
+//		b.WriteString(lipgloss.NewStyle().Background(c).Render(" "))
+//	}
+//
+//	lipgloss.Println(b.String())
+func Blend(size int, points ...color.Color) []color.Color {
+	if len(points) < 2 {
+		return nil
+	}
+
+	stops := make([]colorful.Color, len(points))
+	for i, k := range points {
+		stops[i], _ = colorful.MakeColor(k)
+	}
+
+	numSegments := len(stops) - 1
+	if numSegments == 0 {
+		return nil
+	}
+	blended := make([]color.Color, 0, size)
+
+	// Calculate how many colors each segment should have.
+	segmentSizes := make([]int, numSegments)
+	baseSize := size / numSegments
+	remainder := size % numSegments
+
+	// Distribute the remainder across segments.
+	for i := range numSegments {
+		segmentSizes[i] = baseSize
+		if i < remainder {
+			segmentSizes[i]++
+		}
+	}
+
+	// Generate colors for each segment.
+	for i := range numSegments {
+		c1 := stops[i]
+		c2 := stops[i+1]
+		segmentSize := segmentSizes[i]
+
+		for j := range segmentSize {
+			if segmentSize == 0 {
+				continue
+			}
+			t := float64(j) / float64(segmentSize)
+			c := c1.BlendHcl(c2, t)
+			blended = append(blended, c)
+		}
+	}
+
+	return blended
+}

--- a/exp/color/go.mod
+++ b/exp/color/go.mod
@@ -1,0 +1,5 @@
+module github.com/charmbracelet/x/exp/color
+
+go 1.23.0
+
+require github.com/lucasb-eyer/go-colorful v1.2.0

--- a/exp/color/go.sum
+++ b/exp/color/go.sum
@@ -1,0 +1,2 @@
+github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
+github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=

--- a/go.work
+++ b/go.work
@@ -9,6 +9,7 @@ use (
 	./errors
 	./examples
 	./exp/charmtone
+	./exp/color
 	./exp/golden
 	./exp/higherorder
 	./exp/maps


### PR DESCRIPTION
This moves Charmtone's color blend function to its own package and generalizes it so it can work with any `color.Color`. We're still maintaining `charmtone.Blend` for convenience, however.