### PR TITLE
feat(mosaic): option to maintain aspect ratio of image

### DIFF
--- a/examples/mosaic/main.go
+++ b/examples/mosaic/main.go
@@ -18,7 +18,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	m := mosaic.New().Width(80).Height(40)
+	m := mosaic.New().Width(100).Height(mosaic.Fit)
 
 	fmt.Println(lipgloss.JoinVertical(lipgloss.Right, lipgloss.JoinHorizontal(lipgloss.Center, m.Render(dogImg))))
 }


### PR DESCRIPTION
### Describe your changes

Created a `mosaic.Fit` value that lets you specify only one size of the image to be rendered, while the other one will be calculated in order to maintain the aspect ratio. For example:

```go
mosaic.New().Width(100).Height(mosaic.Fit) // Fits to width
mosaic.New().Height(100).Width(mosaic.Fit) // Fits to height
```

### Related issue/discussion: https://github.com/charmbracelet/x/issues/475

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [x] I have created a discussion
- [x] A project maintainer has approved this feature request. Link to comment:
https://github.com/charmbracelet/x/issues/475#issue-3098347223