### PR TITLE
feat(ansi): add URxvtExt function for URxvt perl extensions

### DIFF
--- a/ansi/urxvt.go
+++ b/ansi/urxvt.go
@@ -1,0 +1,17 @@
+package ansi
+
+import (
+	"fmt"
+	"strings"
+)
+
+// URxvtExt returns an escape sequence for calling a URxvt perl extension with
+// the given name and parameters.
+//
+//	OSC 777 ; extension_name ; param1 ; param2 ; ... ST
+//	OSC 777 ; extension_name ; param1 ; param2 ; ... BEL
+//
+// See: https://man.archlinux.org/man/extra/rxvt-unicode/urxvt.7.en#XTerm_Operating_System_Commands
+func URxvtExt(extension string, params ...string) string {
+	return fmt.Sprintf("\x1b]777;%s;%s\x07", extension, strings.Join(params, ";"))
+}

--- a/ansi/urxvt_test.go
+++ b/ansi/urxvt_test.go
@@ -1,0 +1,39 @@
+package ansi
+
+import "testing"
+
+func TestUrxvtExt(t *testing.T) {
+	tests := []struct {
+		extension string
+		params    []string
+		expected  string
+	}{
+		{
+			extension: "foo",
+			params:    []string{"bar", "baz"},
+			expected:  "\x1b]777;foo;bar;baz\x07",
+		},
+		{
+			extension: "test",
+			params:    []string{},
+			expected:  "\x1b]777;test;\x07",
+		},
+		{
+			extension: "example",
+			params:    []string{"param1"},
+			expected:  "\x1b]777;example;param1\x07",
+		},
+		{
+			extension: "notify",
+			params:    []string{"message", "info"},
+			expected:  "\x1b]777;notify;message;info\x07",
+		},
+	}
+
+	for _, tt := range tests {
+		result := URxvtExt(tt.extension, tt.params...)
+		if result != tt.expected {
+			t.Errorf("URxvtExt(%q, %v) = %q; want %q", tt.extension, tt.params, result, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
One common usage of this escape sequence is sending OS notifications via `OSC 777 ; notify ; title ; body BEL`. This is supported by some terminals like Foot, URxvt, Ghostty, and others.
