### PR TITLE
fix(vt): correct CPR coordinate order in cursor position reports

### DIFF
--- a/vt/handlers.go
+++ b/vt/handlers.go
@@ -802,7 +802,7 @@ func (e *Emulator) registerDefaultCsiHandlers() {
 			_, _ = io.WriteString(e.pw, ansi.DeviceStatusReport(ansi.DECStatusReport(0)))
 		case 6: // Cursor Position Report [ansi.CPR]
 			x, y := e.scr.CursorPosition()
-			_, _ = io.WriteString(e.pw, ansi.CursorPositionReport(x+1, y+1))
+			_, _ = io.WriteString(e.pw, ansi.CursorPositionReport(y+1, x+1))
 		default:
 			return false
 		}
@@ -819,7 +819,7 @@ func (e *Emulator) registerDefaultCsiHandlers() {
 		switch n {
 		case 6: // Extended Cursor Position Report [ansi.DECXCPR]
 			x, y := e.scr.CursorPosition()
-			_, _ = io.WriteString(e.pw, ansi.ExtendedCursorPositionReport(x+1, y+1, 0)) // We don't support page numbers //nolint:errcheck
+			_, _ = io.WriteString(e.pw, ansi.ExtendedCursorPositionReport(y+1, x+1, 0)) // We don't support page numbers //nolint:errcheck
 		default:
 			return false
 		}


### PR DESCRIPTION
## Summary

Fixes a bug in the VT terminal emulator where Cursor Position Report (CPR) responses were returning coordinates in the wrong order.

## Problem

The CPR handler was passing coordinates to the report functions in the wrong order:
- `CursorPosition()` returns `(x, y)` where x=column, y=row
- `CursorPositionReport()` expects `(line, column)` which is `(y, x)`

The handlers were incorrectly calling:
```go
ansi.CursorPositionReport(x+1, y+1)  // Wrong: (column, row)
```

Instead of:
```go
ansi.CursorPositionReport(y+1, x+1)  // Correct: (row, column)
```

## Impact

This bug caused shells that rely on CPR queries (such as nushell) to receive incorrect cursor positions, leading to:
- Incorrect prompt placement
- Screen clearing issues
- Confusing display behavior

## Changes

- Fixed coordinate order in standard CPR handler (ESC[6n)
- Fixed coordinate order in extended CPR handler (ESC[?6n)

## Testing

All existing tests pass with these changes.