### PR TITLE
term: add MakeRawOutput function

### DIFF
--- a/term/term.go
+++ b/term/term.go
@@ -19,6 +19,12 @@ func MakeRaw(fd uintptr) (*State, error) {
 	return makeRaw(fd)
 }
 
+// MakeRawOutput puts the terminal into raw mode for input while preserving
+// output processing.
+func MakeRawOutput(fd uintptr) (*State, error) {
+	return makeRawOutput(fd)
+}
+
 // GetState returns the current state of a terminal which may be useful to
 // restore the terminal after a signal.
 func GetState(fd uintptr) (*State, error) {

--- a/term/term_other.go
+++ b/term/term_other.go
@@ -18,6 +18,10 @@ func makeRaw(fd uintptr) (*State, error) {
 	return nil, fmt.Errorf("terminal: MakeRaw not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
 }
 
+func makeRawOutput(fd uintptr) (*State, error) {
+	return nil, fmt.Errorf("terminal: MakeRawOutput not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+}
+
 func getState(fd uintptr) (*State, error) {
 	return nil, fmt.Errorf("terminal: GetState not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
 }

--- a/term/term_plan9.go
+++ b/term/term_plan9.go
@@ -52,6 +52,10 @@ func makeRaw(fd uintptr) (*State, error) {
 	return &State{state: state{termName: t, raw: true, ctl: ctl}}, nil
 }
 
+func makeRawOutput(fd uintptr) (*State, error) {
+	return makeRaw(fd)
+}
+
 func getState(fd uintptr) (*State, error) {
 	t, err := termName(fd)
 	if err != nil {

--- a/term/term_windows.go
+++ b/term/term_windows.go
@@ -32,6 +32,10 @@ func makeRaw(fd uintptr) (*State, error) {
 	return &State{state{st}}, nil
 }
 
+func makeRawOutput(fd uintptr) (*State, error) {
+	return makeRaw(fd)
+}
+
 func setState(fd uintptr, state *State) error {
 	var mode uint32
 	if state != nil {


### PR DESCRIPTION
Add MakeRawOutput function that puts the terminal into raw mode for input while preserving output processing flags (OPOST/ONLCR). This allows special keys (arrows, etc.) to be captured properly while keeping standard output functions like println() and logging libraries working correctly.

Unlike MakeRaw, this preserves the terminal's output processing so that newlines (\n) are automatically converted to carriage return + newline (\r\n), making standard output functions work as expected.

This is useful for applications that need proper keyboard input handling but want to use standard logging libraries or print statements without manual \r\n handling.

Implementations:
- Unix: Sets raw mode for input but keeps OPOST and ONLCR flags enabled
- Windows: Same as MakeRaw (output processing is separate on Windows)
- Plan 9: Same as MakeRaw (Plan 9 handles output differently)
- Other platforms: Returns appropriate error message

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
