### PR TITLE
fix(powernap): use req.Notif to detect notifications in Router

### DIFF
--- a/powernap/pkg/transport/router.go
+++ b/powernap/pkg/transport/router.go
@@ -57,22 +57,30 @@ func (r *Router) Route(ctx context.Context, req *jsonrpc2.Request) (any, error) 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	// Check if it's a notification (no ID)
-	if req.ID == (jsonrpc2.ID{}) {
+	// Safely extract params, defaulting to "null" if not present.
+	params := json.RawMessage("null")
+	if req.Params != nil {
+		params = *req.Params
+	}
+
+	// Check if it's a notification (no ID). Use req.Notif rather than
+	// comparing the ID to its zero value because jsonrpc2.ID{} (Num: 0)
+	// is indistinguishable from a legitimate integer ID of 0.
+	if req.Notif {
 		if handler, ok := r.notificationHandlers[req.Method]; ok {
-			handler(ctx, req.Method, *req.Params)
+			handler(ctx, req.Method, params)
 		}
 		return nil, nil
 	}
 
 	// It's a request
 	if handler, ok := r.handlers[req.Method]; ok {
-		return handler(ctx, req.Method, *req.Params)
+		return handler(ctx, req.Method, params)
 	}
 
 	// Use default handler if available
 	if r.defaultHandler != nil {
-		return r.defaultHandler(ctx, req.Method, *req.Params)
+		return r.defaultHandler(ctx, req.Method, params)
 	}
 
 	return nil, fmt.Errorf("no handler for method: %s", req.Method)


### PR DESCRIPTION
`Router.Route` compared `req.ID` to `jsonrpc2.ID{}` to distinguish notifications from requests. Since `jsonrpc2.ID{}` has `Num: 0`, any server-initiated request with integer ID 0 (e.g. the first outgoing request from lsp_server/ty) was misrouted as a notification, skipping its registered handler entirely.

Use `req.Notif` instead, which is correctly set by `Request.UnmarshalJSON` based on whether the "id" field is present in the JSON.

Also guard against nil `req.Params` to prevent panics when a server sends a request or notification without a params field.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
