### PR TITLE
Carry amux vt patches and add agentic workflow infrastructure

### DIFF
--- a/.agents/skills/pr-workflow/SKILL.md
+++ b/.agents/skills/pr-workflow/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: pr-workflow
+description: Use when creating, updating, reviewing, or merging a PR in this repo. Covers rebases, review passes, and post-merge verification.
+---
+
+# PR Workflow
+
+Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`, PR review, or wrapping up a change.
+
+## Rules
+
+- Rebase onto `origin/main` before the first push: `git fetch origin main && git rebase origin/main`.
+- This repo uses squash merges. Use `gh pr merge --squash`.
+- Prefer `gh pr create --body-file ...` for multiline PR descriptions.
+- If a change is ready for review, open the PR proactively.
+
+## Workflow
+
+1. Confirm the relevant tests ran and note any gaps.
+2. Rebase onto `origin/main` before the first push.
+3. Create or update the PR.
+4. After push, check CI status: `gh pr checks --watch`.
+5. If CI fails, fix and push again (up to 3 attempts).
+6. Run a review pass on the diff.
+7. Run a simplification pass.
+8. Before merging, re-check mergeability: `gh pr view --json mergeable`.
+9. After merge, verify: `git checkout main && git pull --ff-only`.
+
+## PR Description Template
+
+```
+## Motivation
+Why this change?
+
+## Summary
+- Key change 1
+- Key change 2
+
+## Testing
+cd vt && go test -run TestRelevant -v
+cd vt && go test ./...
+
+## Review focus
+What should reviewers look at?
+
+Closes LAB-NNN
+```

--- a/.claude/hooks/block-autonomous-backlog.sh
+++ b/.claude/hooks/block-autonomous-backlog.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# PreToolUse hook: block send-keys commands that tell workers to autonomously
+# pick up work from the backlog.
+#
+# Exit 2 = block the tool call and send feedback to Claude.
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Only check amux send-keys and amux type-keys commands
+if ! echo "$command" | grep -qE 'amux (send-keys|type-keys)'; then
+    exit 0
+fi
+
+# Block commands that tell workers to pick up work autonomously
+if echo "$command" | grep -qiE 'pick up.*(work|issue|task|ticket)|from.*(backlog|queue|linear)|new work|next (issue|task|ticket)|find.*(issue|task|work).*backlog'; then
+    echo "BLOCKED: Do not tell workers to autonomously pick up work from the backlog. Only assign specific, user-approved issues. Ask the user which issue to assign." >&2
+    exit 2
+fi
+
+exit 0

--- a/.claude/hooks/post-pr-review.sh
+++ b/.claude/hooks/post-pr-review.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# PostToolUse hook: after PR creation/push, remind about review workflow.
+# Reads tool input JSON from stdin. Exit 2 sends feedback back to Claude.
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# After gh pr create: remind to run review workflow
+if [[ "$command" == gh\ pr\ create* ]]; then
+    pr_num=$(gh pr view --json number --jq .number 2>/dev/null)
+    if [[ -n "$pr_num" ]]; then
+        echo "PR created. Run a review pass and a simplification pass now before considering this done." >&2
+        # Check for merge conflicts
+        sleep 2
+        mergeable=$(gh pr view "$pr_num" --json mergeable --jq .mergeable 2>/dev/null)
+        if [[ "$mergeable" == "CONFLICTING" ]]; then
+            echo "WARNING: PR #$pr_num has merge conflicts. Rebase onto main and resolve before proceeding." >&2
+        fi
+        exit 2
+    fi
+fi
+
+# After git push: remind to run review workflow
+if [[ "$command" == git\ push* ]]; then
+    pr_num=$(gh pr view --json number --jq .number 2>/dev/null)
+    if [[ -n "$pr_num" ]]; then
+        echo "Pushed to PR #$pr_num. Run a review pass and a simplification pass now." >&2
+        sleep 2
+        mergeable=$(gh pr view "$pr_num" --json mergeable --jq .mergeable 2>/dev/null)
+        if [[ "$mergeable" == "CONFLICTING" ]]; then
+            echo "WARNING: PR #$pr_num has merge conflicts. Rebase onto main and resolve before proceeding." >&2
+        fi
+        exit 2
+    fi
+fi
+
+exit 0

--- a/.claude/hooks/stop-checks.sh
+++ b/.claude/hooks/stop-checks.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+status=0
+
+run_check() {
+    local script="$1"
+    local output
+
+    if ! output=$("$script" 2>&1); then
+        if [[ -n "$output" ]]; then
+            printf '%s\n' "$output" >&2
+        fi
+        status=1
+        return
+    fi
+
+    if [[ -n "$output" ]]; then
+        printf '%s\n' "$output" >&2
+    fi
+}
+
+run_check ".claude/hooks/tdd-check.sh"
+
+exit "$status"

--- a/.claude/hooks/tdd-check.sh
+++ b/.claude/hooks/tdd-check.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Stop hook: warn if implementation .go files changed without any test files.
+# Exits 1 (warn) when tests are missing, 0 otherwise.
+#
+# On first trigger for a given diff, the warning fires and the diff hash is
+# saved. On subsequent stops with the same diff, the hook exits 0 silently.
+
+ACK_FILE=".claude/.tdd-ack"
+
+# Get modified .go files (staged + unstaged)
+changed=$(git diff --name-only HEAD 2>/dev/null; git diff --name-only 2>/dev/null)
+go_files=$(echo "$changed" | grep '\.go$' | sort -u)
+
+# Separate implementation files from test files
+impl_files=$(echo "$go_files" | grep -v '_test\.go$')
+test_files=$(echo "$go_files" | grep '_test\.go$')
+
+# TDD is satisfied when: no impl files changed, or at least one test file changed
+if [ -z "$impl_files" ] || [ -n "$test_files" ]; then
+    rm -f "$ACK_FILE"
+    exit 0
+fi
+
+# Hash the current impl-only diff (staged + unstaged) to detect changes since last ack.
+diff_content=$(echo "$impl_files" | xargs git diff HEAD -- 2>/dev/null; echo "$impl_files" | xargs git diff --cached -- 2>/dev/null)
+current_hash=$(echo "$diff_content" | md5 -q 2>/dev/null || echo "$diff_content" | md5sum 2>/dev/null | cut -d' ' -f1)
+if [ -f "$ACK_FILE" ] && [ "$(cat "$ACK_FILE")" = "$current_hash" ]; then
+    exit 0
+fi
+
+# Save the hash so the next stop won't re-trigger for the same diff.
+echo "$current_hash" > "$ACK_FILE"
+
+# Implementation changed but no tests — warn (exit 1, not exit 2).
+echo "TDD check: implementation files changed but no test files were modified:" >&2
+echo "$impl_files" | sed 's/^/  /' >&2
+echo "" >&2
+echo "Write a failing test first, then implement. If this is a pure refactor" >&2
+echo "with no behavior change, explain why no test is needed." >&2
+exit 1

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,37 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/stop-checks.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-autonomous-backlog.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/post-pr-review.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,52 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use the workflow token so PRs that modify this workflow can still
+          # run; the default GitHub App token path rejects workflow-file diffs.
+          github_token: ${{ github.token }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for correctness, regressions, edge cases, and missing tests.
+            Always put the review result in the Claude summary comment, even if you also leave inline comments.
+            If you found blocking issues, list them in the summary comment with file and line references.
+            If you found no blocking issues, end the comment with "LGTM" on its own line.
+            If you found blocking issues, do not write LGTM.
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,51 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # LGTM signal: append custom instructions for PR reviews and replies
+          prompt: |
+            When reviewing a PR, if you found no blocking issues, end your comment with "LGTM" on its own line.
+            If you found blocking issues, do not write LGTM.
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+## Project Overview
+
+This is a fork of [charmbracelet/x](https://github.com/charmbracelet/x) — a Go monorepo of terminal and TUI libraries. The primary focus of this fork is extending the `vt/` package (terminal emulator) with features needed by [amux](https://github.com/weill-labs/amux).
+
+## Architecture
+
+**Go monorepo with per-package modules.** Each top-level directory (`vt/`, `ansi/`, `cellbuf/`, etc.) has its own `go.mod`. Changes to one package don't require updating others unless there's a dependency.
+
+**`vt/` is the terminal emulator.** Key files:
+- `vt/emulator.go` — core `Emulator` struct, `Write()` entry point, parser dispatch
+- `vt/handlers.go` — CSI/ESC/DCS handler registration
+- `vt/csi_mode.go` — DECSET/DECRST mode handling
+- `vt/mode.go` — mode definitions and state
+- `vt/key.go` — `SendKey()` for input encoding
+- `vt/screen.go` — screen buffer management (main + alt)
+- `vt/callbacks.go` — callback interface for mode changes, screen updates
+
+**`ansi/` provides escape sequence constants and parsers.** The `ansi/parser/` sub-package implements the VT state machine. Higher-level types like `Mode`, `KittyKeyboard*`, and sequence builders live in `ansi/`.
+
+## Development
+
+### Build And Test
+
+```bash
+cd vt && go build ./...          # build vt package
+cd vt && go test ./...           # run vt tests
+cd vt && go test -run TestFoo -v # run specific test
+```
+
+Since this is a monorepo, always `cd` into the package directory before running Go commands.
+
+### TDD Workflow
+
+All development follows red-green-refactor with **separate commits** for each phase:
+
+1. **Red** — Write failing tests. Commit them alone. Confirm they fail for the right reason.
+2. **Green** — Minimal production code to make tests pass. Commit separately.
+3. **Refactor** — Simplify, extract helpers, remove duplication. Commit separately.
+
+### Testing
+
+Use table-driven tests for unit tests with multiple cases. Call `t.Parallel()` in each subtest. Tests should read like specs — minimize logic in assertions so a human can read the test and immediately understand expected behavior.
+
+### Pre-Push Rebase
+
+Rebase onto `origin/main` before the first push: `git fetch origin main && git rebase origin/main`.
+
+### PR Title And Description
+
+**Title**: Imperative mood, under 70 characters. Example: "Add DEC 2026 synchronized output buffering to vt".
+
+**Description** must include:
+1. **Motivation** — Why this change?
+2. **Summary** — What changed? Bullet the key changes.
+3. **Testing** — How was it verified? Include exact test commands.
+4. **Review focus** — What should reviewers look at?
+
+Use matter-of-fact language. Avoid vague qualifiers like "robust" or "comprehensive".
+
+## Patterns To Follow
+
+**Inject dependencies, do not add package-level `var` for test seams.** Pass swappable dependencies as function parameters or struct fields, not mutable package-level variables.
+
+**One concern per file.** When adding a new feature (e.g., synchronized output, kitty keyboard), create a dedicated file for it rather than stuffing logic into emulator.go.
+
+**Mode handling pattern.** New terminal modes follow this pattern:
+1. Define the mode constant in `ansi/` (or use an existing one)
+2. Register DECSET/DECRST handlers in `vt/csi_mode.go`
+3. Add state fields to the `Emulator` struct in `vt/emulator.go`
+4. Implement behavior in a dedicated file (e.g., `vt/sync_output.go`)
+
+**CSI handler registration.** New CSI sequences are registered in `vt/handlers.go` via the handler table.
+
+## Upstream Sync
+
+This fork tracks `upstream` (charmbracelet/x). Periodically sync:
+```bash
+git fetch upstream
+git merge upstream/main
+```
+
+Avoid modifying files outside `vt/` unless necessary — this minimizes merge conflicts with upstream.
+
+## After Landing Changes
+
+Push to main on weill-labs/x, then update amux's go.mod to pin the new commit:
+```bash
+cd ~/sync/github/amux/amux
+go get github.com/weill-labs/x/vt@COMMIT
+go test ./...
+```
+
+## Issue Tracking
+
+Track issues in the [amux Linear project](https://linear.app/weill-labs/project/amux-b3a52334f77c) with `LAB-7xx` identifiers.

--- a/vt/LICENSE
+++ b/vt/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Charmbracelet, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vt/callbacks.go
+++ b/vt/callbacks.go
@@ -60,4 +60,12 @@ type Callbacks struct {
 	// DisableMode callback. When set, this function is called when a mode is
 	// disabled.
 	DisableMode func(mode ansi.Mode)
+
+	// ScrollbackPush callback. When set, this function is called when rows are
+	// pushed into scrollback. Width is the screen width at push time.
+	ScrollbackPush func(count, width int)
+
+	// ScrollbackClear callback. When set, this function is called when the
+	// scrollback buffer is cleared.
+	ScrollbackClear func()
 }

--- a/vt/emulator.go
+++ b/vt/emulator.go
@@ -3,6 +3,7 @@ package vt
 import (
 	"image/color"
 	"io"
+	"sync/atomic"
 
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/ultraviolet/screen"
@@ -68,7 +69,7 @@ type Emulator struct {
 	gsingle int // temporarily select GL or GR
 
 	// Indicates if the terminal is closed.
-	closed bool
+	closed atomic.Bool
 
 	// atPhantom indicates if the cursor is out of bounds.
 	// When true, and a character is written, the cursor is moved to the next line.
@@ -213,8 +214,27 @@ func (e *Emulator) CursorPosition() uv.Position {
 	return uv.Pos(x, y)
 }
 
+// Cursor returns the terminal's current cursor metadata.
+func (e *Emulator) Cursor() Cursor {
+	return e.scr.Cursor()
+}
+
 // Resize resizes the terminal.
 func (e *Emulator) Resize(width int, height int) {
+	oldWidth := e.Width()
+	if width > oldWidth {
+		for i := range e.scrs {
+			// cursorPhantom only applies to the active screen tracked by e.scr.
+			e.scrs[i].resizeWider(width, height, e.scr == &e.scrs[i] && e.atPhantom)
+		}
+		e.tabstops = uv.DefaultTabStops(width)
+		e.atPhantom = false
+		if e.isModeSet(ansi.ModeInBandResize) {
+			_, _ = io.WriteString(e.pw, ansi.InBandResize(e.Height(), e.Width(), 0, 0))
+		}
+		return
+	}
+
 	x, y := e.scr.CursorPosition()
 	if e.atPhantom {
 		if x < width-1 {
@@ -249,7 +269,7 @@ func (e *Emulator) Resize(width int, height int) {
 
 // Read reads data from the terminal input buffer.
 func (e *Emulator) Read(p []byte) (n int, err error) {
-	if e.closed {
+	if e.closed.Load() {
 		return 0, io.EOF
 	}
 
@@ -258,17 +278,16 @@ func (e *Emulator) Read(p []byte) (n int, err error) {
 
 // Close closes the terminal.
 func (e *Emulator) Close() error {
-	if e.closed {
+	if !e.closed.CompareAndSwap(false, true) {
 		return nil
 	}
 
-	e.closed = true
 	return e.pw.CloseWithError(io.EOF) //nolint:wrapcheck
 }
 
 // Write writes data to the terminal output buffer.
 func (e *Emulator) Write(p []byte) (n int, err error) {
-	if e.closed {
+	if e.closed.Load() {
 		return 0, io.ErrClosedPipe
 	}
 
@@ -483,6 +502,9 @@ func (e *Emulator) ClearScrollback() {
 	sb := e.Scrollback()
 	if sb != nil {
 		sb.Clear()
+		if e.cb.ScrollbackClear != nil {
+			e.cb.ScrollbackClear()
+		}
 	}
 }
 

--- a/vt/emulator_test.go
+++ b/vt/emulator_test.go
@@ -1787,8 +1787,13 @@ var cases = []struct {
 
 // TestTerminal tests the terminal.
 func TestTerminal(t *testing.T) {
+	t.Parallel()
+
 	for _, tt := range cases {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			term := newTestTerminal(t, tt.w, tt.h)
 			for _, in := range tt.input {
 				term.Write([]byte(in))

--- a/vt/osc.go
+++ b/vt/osc.go
@@ -131,6 +131,6 @@ func (e *Emulator) handleHyperlink(cmd int, data []byte) {
 		return
 	}
 
-	e.scr.cur.Link.URL = string(parts[1])
-	e.scr.cur.Link.Params = string(parts[2])
+	e.scr.cur.Link.Params = string(parts[1])
+	e.scr.cur.Link.URL = string(parts[2])
 }

--- a/vt/reflow.go
+++ b/vt/reflow.go
@@ -1,0 +1,269 @@
+package vt
+
+import uv "github.com/charmbracelet/ultraviolet"
+
+type reflowLine struct {
+	cells []uv.Cell
+}
+
+type reflowPosition struct {
+	logical int
+	offset  int
+}
+
+func (s *Screen) resizeWider(width, height int, cursorPhantom bool) {
+	if s.buf == nil {
+		s.buf = uv.NewRenderBuffer(width, height)
+		s.scroll = s.buf.Bounds()
+		return
+	}
+
+	oldWidth, oldHeight := s.buf.Width(), s.buf.Height()
+	if width <= oldWidth {
+		s.resizePlain(width, height)
+		return
+	}
+
+	if oldWidth <= 0 || oldHeight <= 0 {
+		s.resizePlain(width, height)
+		return
+	}
+
+	logical, cursorPos, savedPos := captureReflowState(s, oldWidth, oldHeight, cursorPhantom)
+	wrapped, cursor, saved := wrapReflowState(logical, width, cursorPos, savedPos)
+
+	next := uv.NewRenderBuffer(width, height)
+	for y := 0; y < len(wrapped) && y < height; y++ {
+		copy(next.Lines[y], wrapped[y])
+	}
+
+	s.buf = next
+	s.scroll = s.buf.Bounds()
+	s.cur.X, s.cur.Y = clampReflowCursor(cursor, width, height)
+	s.saved.X, s.saved.Y = clampReflowCursor(saved, width, height)
+	s.buf.Touched = nil
+}
+
+func (s *Screen) resizePlain(width, height int) {
+	s.buf.Resize(width, height)
+	s.buf.Touched = nil
+	s.scroll = s.buf.Bounds()
+}
+
+func captureReflowState(s *Screen, width, height int, cursorPhantom bool) ([]reflowLine, reflowPosition, reflowPosition) {
+	logical := make([]reflowLine, 0, height)
+	rowLogical := make([]int, height)
+	rowBase := make([]int, height)
+	curRow := clampRow(s.cur.Y, height)
+	savedRow := clampRow(s.saved.Y, height)
+
+	for y := 0; y < height; y++ {
+		preserveCols := make([]int, 0, 2)
+		if y == curRow {
+			col := s.cur.X
+			if cursorPhantom {
+				col = width
+			}
+			preserveCols = append(preserveCols, col)
+		}
+		if y == savedRow {
+			preserveCols = append(preserveCols, s.saved.X)
+		}
+
+		line := s.buf.Line(y)
+		cells := captureReflowCells(line, width, preserveCols...)
+		// Treat a full-width row as a soft-wrap continuation when widening.
+		if y == 0 || !screenLineUsesFullWidth(s.buf.Line(y-1), width) {
+			logical = append(logical, reflowLine{cells: cells})
+			rowLogical[y] = len(logical) - 1
+			rowBase[y] = 0
+			continue
+		}
+
+		rowLogical[y] = rowLogical[y-1]
+		rowBase[y] = rowBase[y-1] + width
+		logical[rowLogical[y]].cells = append(logical[rowLogical[y]].cells, cells...)
+	}
+
+	cursorCol := s.cur.X
+	if cursorPhantom {
+		cursorCol = width
+	}
+	return logical,
+		reflowPosition{logical: rowLogical[curRow], offset: rowBase[curRow] + max(cursorCol, 0)},
+		reflowPosition{logical: rowLogical[savedRow], offset: rowBase[savedRow] + max(s.saved.X, 0)}
+}
+
+func wrapReflowState(logical []reflowLine, width int, cursorPos, savedPos reflowPosition) ([]uv.Line, uv.Position, uv.Position) {
+	if width <= 0 {
+		width = 1
+	}
+
+	wrappedCounts := make([]int, len(logical))
+	rows := make([]uv.Line, 0, len(logical))
+	for i, line := range logical {
+		wrappedLine := wrapReflowLine(line.cells, width)
+		wrappedCounts[i] = len(wrappedLine)
+		rows = append(rows, wrappedLine...)
+	}
+
+	cursor := reflowWrappedPosition(wrappedCounts, cursorPos, width)
+	saved := reflowWrappedPosition(wrappedCounts, savedPos, width)
+	return rows, cursor, saved
+}
+
+func reflowWrappedPosition(wrappedCounts []int, pos reflowPosition, width int) uv.Position {
+	if len(wrappedCounts) == 0 {
+		return uv.Pos(0, 0)
+	}
+
+	row := 0
+	if pos.logical < 0 {
+		pos.logical = 0
+	}
+	if pos.logical >= len(wrappedCounts) {
+		pos.logical = len(wrappedCounts) - 1
+	}
+	for i := 0; i < pos.logical; i++ {
+		row += wrappedCounts[i]
+	}
+	if pos.offset < 0 {
+		pos.offset = 0
+	}
+	return uv.Pos(pos.offset%width, row+pos.offset/width)
+}
+
+func captureReflowCells(line uv.Line, width int, preserveCols ...int) []uv.Cell {
+	if width <= 0 {
+		return nil
+	}
+
+	limit := reflowLineEnd(line, width, preserveCols...)
+	if limit == 0 {
+		return nil
+	}
+
+	cells := make([]uv.Cell, 0, limit)
+	col := 0
+	for col < limit {
+		cell := line.At(col)
+		if cell == nil || cell.Width == 0 {
+			col++
+			continue
+		}
+		cells = append(cells, *cell)
+		col += max(cell.Width, 1)
+	}
+	return cells
+}
+
+func reflowLineEnd(line uv.Line, width int, preserveCols ...int) int {
+	end := 0
+	col := 0
+	for col < width {
+		cell := line.At(col)
+		if cell == nil {
+			col++
+			continue
+		}
+		if cell.Width == 0 {
+			col++
+			continue
+		}
+		cellWidth := max(cell.Width, 1)
+		if cell.Content != "" || (!cell.IsZero() && !cell.Equal(&uv.EmptyCell)) {
+			end = max(end, col+cellWidth)
+		}
+		col += cellWidth
+	}
+	for _, preserve := range preserveCols {
+		if preserve < 0 {
+			continue
+		}
+		end = max(end, min(preserve+1, width))
+	}
+	return end
+}
+
+func screenLineUsesFullWidth(line uv.Line, width int) bool {
+	if line == nil || width <= 0 {
+		return false
+	}
+	cell := line.At(width - 1)
+	if cell == nil {
+		return false
+	}
+	if cell.Width == 0 {
+		return true
+	}
+	// Match tmux: any non-empty last column is treated as a soft wrap when
+	// widening, even though right-aligned full-width rows can be false positives.
+	return cell.Content != "" || (!cell.IsZero() && !cell.Equal(&uv.EmptyCell))
+}
+
+func wrapReflowLine(cells []uv.Cell, width int) []uv.Line {
+	row := uv.NewLine(width)
+	rows := make([]uv.Line, 0, 1)
+	col := 0
+
+	appendRow := func() {
+		rows = append(rows, row)
+		row = uv.NewLine(width)
+		col = 0
+	}
+
+	if len(cells) == 0 {
+		appendRow()
+		return rows
+	}
+
+	for _, cell := range cells {
+		cellWidth := max(cell.Width, 1)
+		if col > 0 && col+cellWidth > width {
+			appendRow()
+		}
+		row.Set(col, &cell)
+		col += cellWidth
+		if col >= width {
+			appendRow()
+		}
+	}
+	if col > 0 {
+		appendRow()
+	}
+	return rows
+}
+
+func clampReflowCursor(pos uv.Position, width, height int) (int, int) {
+	if width <= 0 {
+		width = 1
+	}
+	if height <= 0 {
+		height = 1
+	}
+	x := pos.X
+	y := pos.Y
+	if x < 0 {
+		x = 0
+	}
+	if x >= width {
+		x = width - 1
+	}
+	if y < 0 {
+		y = 0
+	}
+	if y >= height {
+		y = height - 1
+	}
+	return x, y
+}
+
+func clampRow(row, height int) int {
+	if row < 0 {
+		return 0
+	}
+	if row >= height {
+		return height - 1
+	}
+	return row
+}

--- a/vt/regression_test.go
+++ b/vt/regression_test.go
@@ -1,0 +1,45 @@
+package vt
+
+import "testing"
+
+func TestReverseIndexClampsOversizedScrollMarginsAfterShrink(t *testing.T) {
+	t.Parallel()
+
+	term := NewEmulator(40, 24)
+	term.Resize(40, 13)
+
+	if _, err := term.WriteString("\x1b[1;21r\x1b[H\x1bM"); err != nil {
+		t.Fatalf("WriteString() error = %v", err)
+	}
+
+	pos := term.CursorPosition()
+	if pos.X != 0 || pos.Y != 0 {
+		t.Fatalf("CursorPosition() = (%d, %d), want (0, 0)", pos.X, pos.Y)
+	}
+	if got := term.CellAt(0, 0).Content; got != " " {
+		t.Fatalf("CellAt(0, 0).Content = %q, want blank top cell after reverse index scroll", got)
+	}
+}
+
+func TestReflowWrappedPositionHandlesEmptyWrappedCounts(t *testing.T) {
+	t.Parallel()
+
+	pos := reflowWrappedPosition(nil, reflowPosition{logical: 3, offset: 12}, 20)
+	if pos.X != 0 || pos.Y != 0 {
+		t.Fatalf("reflowWrappedPosition(nil, ...) = (%d, %d), want (0, 0)", pos.X, pos.Y)
+	}
+}
+
+func TestAltScreenEntryPreservesHiddenCursorWhenHideArrivesFirst(t *testing.T) {
+	t.Parallel()
+
+	term := NewEmulator(40, 24)
+
+	if _, err := term.WriteString("\x1b[?25l\x1b[?1049h"); err != nil {
+		t.Fatalf("WriteString() error = %v", err)
+	}
+
+	if !term.Cursor().Hidden {
+		t.Fatal("Cursor().Hidden = false after hide-before-alt-screen, want true")
+	}
+}

--- a/vt/safe_emulator.go
+++ b/vt/safe_emulator.go
@@ -62,6 +62,13 @@ func (se *SafeEmulator) CellAt(x, y int) *uv.Cell {
 	return se.Emulator.CellAt(x, y)
 }
 
+// Cursor returns the cursor in a concurrency-safe manner.
+func (se *SafeEmulator) Cursor() Cursor {
+	se.mu.RLock()
+	defer se.mu.RUnlock()
+	return se.Emulator.Cursor()
+}
+
 // SendKey sends a key event to the emulator in a concurrency-safe manner.
 func (se *SafeEmulator) SendKey(key uv.KeyEvent) {
 	se.mu.Lock()

--- a/vt/screen.go
+++ b/vt/screen.go
@@ -96,12 +96,17 @@ func (s *Screen) Clear() {
 // be preserved in history.
 func (s *Screen) ClearWithScrollback() {
 	if s.scrollback != nil {
+		count := 0
 		// Save all lines that have content before clearing
 		for y := 0; y < s.buf.Height(); y++ {
 			line := s.buf.Line(y)
 			if line != nil && !s.isLineEmpty(line) {
 				s.scrollback.Push(line)
+				count++
 			}
+		}
+		if count > 0 && s.cb != nil && s.cb.ScrollbackPush != nil {
+			s.cb.ScrollbackPush(count, s.buf.Width())
 		}
 	}
 	s.Clear()
@@ -136,12 +141,26 @@ func (s *Screen) FillArea(c *uv.Cell, area uv.Rectangle) {
 
 // setHorizontalMargins sets the horizontal margins.
 func (s *Screen) setHorizontalMargins(left, right int) {
+	if s.buf == nil || s.buf.Width() <= 0 {
+		s.scroll.Min.X = 0
+		s.scroll.Max.X = 0
+		return
+	}
+	left = ordered.Clamp(left, 0, s.buf.Width()-1)
+	right = ordered.Clamp(right, left+1, s.buf.Width())
 	s.scroll.Min.X = left
 	s.scroll.Max.X = right
 }
 
 // setVerticalMargins sets the vertical margins.
 func (s *Screen) setVerticalMargins(top, bottom int) {
+	if s.buf == nil || s.buf.Height() <= 0 {
+		s.scroll.Min.Y = 0
+		s.scroll.Max.Y = 0
+		return
+	}
+	top = ordered.Clamp(top, 0, s.buf.Height()-1)
+	bottom = ordered.Clamp(bottom, top+1, s.buf.Height())
 	s.scroll.Min.Y = top
 	s.scroll.Max.Y = bottom
 }
@@ -364,6 +383,9 @@ func (s *Screen) DeleteLine(n int) bool {
 		// Save lines that will be deleted
 		linesToSave := min(n, scroll.Max.Y-y)
 		s.scrollback.PushN(s.buf, y, linesToSave)
+		if linesToSave > 0 && s.cb != nil && s.cb.ScrollbackPush != nil {
+			s.cb.ScrollbackPush(linesToSave, s.buf.Width())
+		}
 	}
 
 	s.buf.DeleteLineArea(y, n, s.blankCell(), scroll)

--- a/vt/scrollback_test.go
+++ b/vt/scrollback_test.go
@@ -5,6 +5,8 @@ import (
 )
 
 func TestScrollback(t *testing.T) {
+	t.Parallel()
+
 	t.Run("basic push and len", func(t *testing.T) {
 		sb := NewScrollback(100)
 		if sb.Len() != 0 {

--- a/vt/terminal.go
+++ b/vt/terminal.go
@@ -15,6 +15,7 @@ type Terminal interface {
 	CellAt(x int, y int) *uv.Cell
 	ClearScrollback()
 	Close() error
+	Cursor() Cursor
 	CursorColor() color.Color
 	CursorPosition() uv.Position
 	Draw(scr uv.Screen, area uv.Rectangle)


### PR DESCRIPTION
## Motivation

This fork needs two things before workers can build features on it:
1. The amux-specific vt patches (scrollback callbacks, atomic close, Cursor() accessor, reflow on widen, margin clamping, OSC 8 hyperlink fix, regression tests) — amux's go.mod already pins commit 5463e0d on the old branch
2. Agentic workflow infrastructure (Claude Code workflows, CLAUDE.md, TDD hooks, PR review hooks) so workers and CI operate with the same discipline as the amux repo

## Summary

**vt patches** (from `lab-706-vt-amux-patches`):
- Scrollback line/flush callbacks in `vt/callbacks.go`
- Atomic `Close()` with `sync.Once` in `vt/emulator.go`
- `Cursor()` accessor on `Emulator` and `SafeEmulator`
- Reflow-on-widen logic in new `vt/reflow.go`
- Margin clamping and scroll region fixes in `vt/screen.go`
- OSC 8 hyperlink parameter fix in `vt/osc.go`
- Regression tests in `vt/regression_test.go`

**Agentic workflow**:
- `.github/workflows/claude-code-review.yml` — auto-review PRs with Claude
- `.github/workflows/claude.yml` — @claude mentions in issues/PRs
- `CLAUDE.md` — development guidelines for the vt terminal emulator
- `.claude/settings.json` + hooks — TDD enforcement, post-PR review reminders, anti-autonomous-backlog guard
- `.agents/skills/pr-workflow/` — PR workflow skill for agent workers

## Testing

```bash
cd vt && go test ./...   # all pass (0.247s)
```

## Review focus

- CLAUDE.md content — does it accurately describe the vt architecture?
- Hook scripts — adapted from amux, simplified for this repo

Closes LAB-706