### PR TITLE
kitty.Options.Quite -> Quiet

### DIFF
--- a/ansi/kitty/options.go
+++ b/ansi/kitty/options.go
@@ -23,6 +23,12 @@ type Options struct {
 	// [Animate], [Compose].
 	Action byte
 
+	// Quite is the kitty graphics quiet mode.
+	//
+	// Deprecated: misspelled field, use [Options.Quiet] instead. Any non-zero
+	// Quite overrides Quiet.
+	Quite byte
+
 	// Quiet mode (q=0) is the quiet mode. Can be either zero, one, or two
 	// where zero is the default, 1 suppresses OK responses, and 2 suppresses
 	// both OK and error responses.
@@ -173,8 +179,13 @@ func (o *Options) Options() (opts []string) {
 		opts = append(opts, fmt.Sprintf("f=%d", o.Format))
 	}
 
-	if o.Quiet > 0 {
-		opts = append(opts, fmt.Sprintf("q=%d", o.Quiet))
+	quiet := o.Quiet
+	if o.Quite > 0 {
+		// handle deprecated Quite field.
+		quiet = o.Quite
+	}
+	if quiet > 0 {
+		opts = append(opts, fmt.Sprintf("q=%d", quiet))
 	}
 
 	if o.ID > 0 {

--- a/ansi/kitty/options.go
+++ b/ansi/kitty/options.go
@@ -23,10 +23,10 @@ type Options struct {
 	// [Animate], [Compose].
 	Action byte
 
-	// Quite mode (q=0) is the quiet mode. Can be either zero, one, or two
+	// Quiet mode (q=0) is the quiet mode. Can be either zero, one, or two
 	// where zero is the default, 1 suppresses OK responses, and 2 suppresses
 	// both OK and error responses.
-	Quite byte
+	Quiet byte
 
 	// Transmission options.
 
@@ -173,8 +173,8 @@ func (o *Options) Options() (opts []string) {
 		opts = append(opts, fmt.Sprintf("f=%d", o.Format))
 	}
 
-	if o.Quite > 0 {
-		opts = append(opts, fmt.Sprintf("q=%d", o.Quite))
+	if o.Quiet > 0 {
+		opts = append(opts, fmt.Sprintf("q=%d", o.Quiet))
 	}
 
 	if o.ID > 0 {
@@ -324,7 +324,7 @@ func (o *Options) UnmarshalText(text []byte) error {
 			case "i":
 				o.ID = v
 			case "q":
-				o.Quite = byte(v)
+				o.Quiet = byte(v)
 			case "p":
 				o.PlacementID = v
 			case "I":

--- a/ansi/kitty/options_test.go
+++ b/ansi/kitty/options_test.go
@@ -151,6 +151,51 @@ func TestOptions_Options(t *testing.T) {
 	}
 }
 
+func TestOptions_QuiteDeprecation(t *testing.T) {
+	tests := []struct {
+		name    string
+		options Options
+		want    []string
+	}{
+		{
+			name:    "Quiet only",
+			options: Options{Quiet: 1},
+			want:    []string{"q=1"},
+		},
+		{
+			name:    "deprecated Quite only",
+			options: Options{Quite: 2},
+			want:    []string{"q=2"},
+		},
+		{
+			name:    "Quite overrides Quiet when non-zero",
+			options: Options{Quiet: 1, Quite: 2},
+			want:    []string{"q=2"},
+		},
+		{
+			name:    "Quite=0 does not override Quiet",
+			options: Options{Quiet: 1, Quite: 0},
+			want:    []string{"q=1"},
+		},
+		{
+			name:    "both zero emits no q= option",
+			options: Options{},
+			want:    []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.options.Options()
+			sortStrings(got)
+			sortStrings(tt.want)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Options.Options() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestOptions_Validation(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -320,6 +365,13 @@ func TestOptions_UnmarshalText(t *testing.T) {
 			name: "unmarshal with invalid number",
 			text: []byte("i=abc"),
 			want: Options{},
+		},
+		{
+			name: "unmarshal q= populates Quiet only, not deprecated Quite",
+			text: []byte("q=1"),
+			want: Options{
+				Quiet: 1,
+			},
 		},
 		{
 			name: "unmarshal with delete resources",

--- a/ansi/kitty/options_test.go
+++ b/ansi/kitty/options_test.go
@@ -117,7 +117,7 @@ func TestOptions_Options(t *testing.T) {
 		{
 			name: "quiet mode and format",
 			options: Options{
-				Quite:  2,
+				Quiet:  2,
 				Format: RGB,
 			},
 			expected: []string{
@@ -214,7 +214,7 @@ func TestOptions_String(t *testing.T) {
 			name: "full options",
 			o: Options{
 				Action:            'A',
-				Quite:             'Q',
+				Quiet:             'Q',
 				Compression:       'C',
 				Transmission:      'T',
 				Delete:            'd',
@@ -273,7 +273,7 @@ func TestOptions_MarshalText(t *testing.T) {
 				ID:              123,
 				Width:           400,
 				Height:          500,
-				Quite:           2,
+				Quiet:           2,
 				DoNotMoveCursor: true,
 			},
 			want: []byte("q=2,i=123,C=1,w=400,h=500,a=A"),

--- a/ansi/kitty/writer.go
+++ b/ansi/kitty/writer.go
@@ -167,8 +167,8 @@ func buildChunkOptions(o *Options, isFirstChunk, isLastChunk bool) []string {
 		opts = o.Options()
 	} else {
 		// These options are allowed in subsequent chunks
-		if o.Quite > 0 {
-			opts = append(opts, fmt.Sprintf("q=%d", o.Quite))
+		if o.Quiet > 0 {
+			opts = append(opts, fmt.Sprintf("q=%d", o.Quiet))
 		}
 		if o.Action == Frame {
 			opts = append(opts, "a=f")

--- a/ansi/kitty/writer.go
+++ b/ansi/kitty/writer.go
@@ -167,8 +167,13 @@ func buildChunkOptions(o *Options, isFirstChunk, isLastChunk bool) []string {
 		opts = o.Options()
 	} else {
 		// These options are allowed in subsequent chunks
-		if o.Quiet > 0 {
-			opts = append(opts, fmt.Sprintf("q=%d", o.Quiet))
+		quiet := o.Quiet
+		if o.Quite > 0 {
+			// handle deprecated Quite field.
+			quiet = o.Quite
+		}
+		if quiet > 0 {
+			opts = append(opts, fmt.Sprintf("q=%d", quiet))
 		}
 		if o.Action == Frame {
 			opts = append(opts, "a=f")

--- a/input/key_test.go
+++ b/input/key_test.go
@@ -160,7 +160,7 @@ func TestParseSequence(t *testing.T) {
 		seqTest{
 			[]byte("\x1b_Gi=1337,q=1;EINVAL:your face\x1b\\"),
 			[]Event{KittyGraphicsEvent{
-				Options: kitty.Options{ID: 1337, Quiet: 1},
+				Options: kitty.Options{ID: 1337, Quite: 1},
 				Payload: []byte("EINVAL:your face"),
 			}},
 		},

--- a/input/key_test.go
+++ b/input/key_test.go
@@ -160,7 +160,7 @@ func TestParseSequence(t *testing.T) {
 		seqTest{
 			[]byte("\x1b_Gi=1337,q=1;EINVAL:your face\x1b\\"),
 			[]Event{KittyGraphicsEvent{
-				Options: kitty.Options{ID: 1337, Quite: 1},
+				Options: kitty.Options{ID: 1337, Quiet: 1},
 				Payload: []byte("EINVAL:your face"),
 			}},
 		},


### PR DESCRIPTION
I was working on code that depended on this an my LLM reviewer suggested I had a typo.  But when I looked upstream in this library, it seems that this quietly crept in?

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
