### PR TITLE
fix(vt): prevent data race between Read/Write/Close in SafeEmulator

### DIFF
--- a/vt/safe_emulator.go
+++ b/vt/safe_emulator.go
@@ -2,6 +2,7 @@ package vt
 
 import (
 	"image/color"
+	"io"
 	"sync"
 
 	uv "github.com/charmbracelet/ultraviolet"
@@ -31,7 +32,21 @@ func (se *SafeEmulator) Write(data []byte) (int, error) {
 
 // Read reads data from the emulator in a concurrency-safe manner.
 func (se *SafeEmulator) Read(p []byte) (int, error) {
-	return se.Emulator.Read(p)
+	se.mu.RLock()
+	if se.closed {
+		se.mu.RUnlock()
+		return 0, io.EOF
+	}
+	pr := se.pr
+	se.mu.RUnlock()
+	return pr.Read(p) //nolint:wrapcheck
+}
+
+// Close closes the terminal in a concurrency-safe manner.
+func (se *SafeEmulator) Close() error {
+	se.mu.Lock()
+	defer se.mu.Unlock()
+	return se.Emulator.Close()
 }
 
 // Resize resizes the emulator in a concurrency-safe manner.

--- a/vt/safe_emulator_test.go
+++ b/vt/safe_emulator_test.go
@@ -1,0 +1,65 @@
+package vt
+
+import (
+	"io"
+	"sync"
+	"testing"
+)
+
+func TestSafeEmulator_ReadAfterClose(t *testing.T) {
+	t.Parallel()
+
+	se := NewSafeEmulator(80, 24)
+	if err := se.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	n, err := se.Read(make([]byte, 1))
+	if n != 0 || err != io.EOF {
+		t.Fatalf("Read after Close: got (%d, %v), want (0, EOF)", n, err)
+	}
+}
+
+func TestSafeEmulator_CloseTwiceThenReadEOF(t *testing.T) {
+	t.Parallel()
+
+	se := NewSafeEmulator(10, 10)
+	if err := se.Close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	if err := se.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+	n, err := se.Read(make([]byte, 8))
+	if n != 0 || err != io.EOF {
+		t.Fatalf("Read: got (%d, %v), want (0, EOF)", n, err)
+	}
+}
+
+func TestSafeEmulator_ConcurrentReadWriteClose(t *testing.T) {
+	t.Parallel()
+
+	const rounds = 50
+	const parallelism = 16
+
+	for range rounds {
+		se := NewSafeEmulator(80, 24)
+		var wg sync.WaitGroup
+		wg.Add(parallelism * 3)
+		for range parallelism {
+			go func() {
+				defer wg.Done()
+				var buf [64]byte
+				_, _ = se.Read(buf[:])
+			}()
+			go func() {
+				defer wg.Done()
+				_, _ = se.Write([]byte{'x'})
+			}()
+			go func() {
+				defer wg.Done()
+				_ = se.Close()
+			}()
+		}
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
## Changes in this PR

- Fixes a data race, due to `SafeEmulator.Close()` (a write) falling through to `Emulator`, where it's also read by `Read()` and `Write()`
- `Read()` also wasn't locking in any form, which was problematic due to the race being with `Emulator.closed` in particular. Can't block the entire operation, since it looks like the pipe reader (`pr`) also blocks.

Only other alternative I could think of would be to use an `atomic.Bool` on `Emulator.closed`, but that bleeds concurrency protection into `Emulator`.

---

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).