### PR TITLE
feat(vt): add Scrollback.Render() for retired-line snapshots

### DIFF
--- a/vt/scrollback.go
+++ b/vt/scrollback.go
@@ -134,3 +134,15 @@ func (s *Scrollback) CellAt(x, y int) *uv.Cell {
 	}
 	return &line[x]
 }
+
+// Render renders the scrollback buffer to a styled string with all the
+// required attributes and styles, matching the encoding used by
+// [Emulator.Render] for the visible screen. Lines are separated by a bare
+// LF; there is no trailing LF after the last line. Returns an empty string
+// when the scrollback is empty or the receiver is nil.
+func (s *Scrollback) Render() string {
+	if s == nil {
+		return ""
+	}
+	return uv.Lines(s.lines).Render()
+}

--- a/vt/scrollback_test.go
+++ b/vt/scrollback_test.go
@@ -221,6 +221,14 @@ func TestScrollback(t *testing.T) {
 		if sb.Len() > 1 && !strings.Contains(got, "\n") {
 			t.Errorf("expected newline separator between lines, got %q", got)
 		}
+		// Pin the LF-only-no-CR contract: callers (terminal
+		// multiplexers like ai-beacon) substitute LF -> CRLF when
+		// targeting receivers without an `onlcr` translation. A
+		// future change that emits CR here would silently double-CR
+		// downstream.
+		if strings.Contains(got, "\r") {
+			t.Errorf("expected no CR in render output (LF-only contract), got %q", got)
+		}
 	})
 
 	t.Run("ED 3 clears scrollback", func(t *testing.T) {

--- a/vt/scrollback_test.go
+++ b/vt/scrollback_test.go
@@ -1,6 +1,7 @@
 package vt
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -141,6 +142,85 @@ func TestScrollback(t *testing.T) {
 			t.Errorf("expected scrollback to grow after ED 2, was %d now %d", initialLen, newLen)
 		}
 		t.Logf("scrollback after ED 2: %d lines", newLen)
+	})
+
+	t.Run("Render returns empty string when scrollback is empty", func(t *testing.T) {
+		sb := NewScrollback(100)
+		if got := sb.Render(); got != "" {
+			t.Errorf("expected empty render, got %q", got)
+		}
+	})
+
+	t.Run("Render returns empty string on nil receiver", func(t *testing.T) {
+		var sb *Scrollback
+		if got := sb.Render(); got != "" {
+			t.Errorf("expected empty render on nil receiver, got %q", got)
+		}
+	})
+
+	t.Run("Render emits content from scrolled-off lines", func(t *testing.T) {
+		// The visible-grid Render() omits retired lines by definition.
+		// A consumer (e.g. a terminal multiplexer rehydrating a
+		// late-attaching client) needs the bytes that have scrolled
+		// off the visible screen so the client can display them in
+		// its own scrollback.
+		e := NewEmulator(20, 5)
+		for i := 1; i <= 10; i++ {
+			e.WriteString("scrolled-line\r\n")
+		}
+		// More than 5 (screen height) means at least 5 lines retired.
+		if e.ScrollbackLen() < 5 {
+			t.Fatalf("expected at least 5 retired lines, got %d", e.ScrollbackLen())
+		}
+
+		got := e.Scrollback().Render()
+		if !strings.Contains(got, "scrolled-line") {
+			t.Errorf("expected render to contain retired line content, got %q", got)
+		}
+	})
+
+	t.Run("Render preserves order from oldest to newest", func(t *testing.T) {
+		e := NewEmulator(20, 3)
+		// Each line is distinct so order is observable in the render.
+		for i := 1; i <= 8; i++ {
+			e.WriteString("line-")
+			e.WriteString(string(rune('0' + i)))
+			e.WriteString("\r\n")
+		}
+
+		got := e.Scrollback().Render()
+		earliest := strings.Index(got, "line-1")
+		latest := strings.LastIndex(got, "line-")
+		if earliest < 0 {
+			t.Fatalf("expected earliest line in render, got %q", got)
+		}
+		if latest <= earliest {
+			t.Errorf("expected oldest-to-newest order; earliest at %d, latest at %d (render: %q)", earliest, latest, got)
+		}
+	})
+
+	t.Run("Render separates lines with newline and no trailing newline", func(t *testing.T) {
+		// Mirrors Lines.Render in ultraviolet: bare LF between lines,
+		// no trailing LF after the last line. This matches the live
+		// grid's Render() row-to-row separator so a consumer that
+		// substitutes LF -> CRLF for live snapshots can reuse the
+		// pipeline verbatim.
+		sb := NewScrollback(100)
+		e := NewEmulator(10, 3)
+		e.WriteString("aaa\r\nbbb\r\nccc\r\nddd\r\n")
+		// Copy the emulator's retired lines into a standalone Scrollback
+		// so the test exercises Render() on an arbitrary instance, not
+		// only the one inside an emulator.
+		for i := 0; i < e.ScrollbackLen(); i++ {
+			sb.Push(e.Scrollback().Line(i))
+		}
+		got := sb.Render()
+		if strings.HasSuffix(got, "\n") {
+			t.Errorf("expected no trailing newline, got %q", got)
+		}
+		if sb.Len() > 1 && !strings.Contains(got, "\n") {
+			t.Errorf("expected newline separator between lines, got %q", got)
+		}
 	})
 
 	t.Run("ED 3 clears scrollback", func(t *testing.T) {


### PR DESCRIPTION
## What

Adds `(*Scrollback).Render() string` — a new method on `vt.Scrollback` that renders the retired-line buffer as a styled string with all the required attributes and styles, mirroring `(*Buffer).Render()` (in `ultraviolet`) and `(*Emulator).Render()` on the live grid.

Implementation is a one-line delegation to the existing public renderer:

```go
func (s *Scrollback) Render() string {
    if s == nil {
        return ""
    }
    return uv.Lines(s.lines).Render()
}
```

## Why

`vt.Scrollback` exposes `Push`, `Len`, `Lines`, `Line`, `CellAt` but no `Render()`. Consumers that want to snapshot retired lines as a styled byte stream (terminal multiplexers, late-attach rehydrators, debug tools) currently have to walk cells via `CellAt(x, y)` and re-implement vt's internal `renderLine` SGR-pen-diff / hyperlink reset logic outside the package. That's fragile — every future fix to pen-reset edge cases, wide-char placeholder handling, hyperlink escape rules, or new cell attributes silently bypasses the external implementation.

This patch closes that gap by reusing `Lines.Render()` from `ultraviolet`, the same renderer `Buffer.Render()` already delegates to. Lines stay LF-separated with no trailing LF — same shape as the live grid's `Render()`.

The motivating consumer is [ai-beacon](https://github.com/manusa/ai-beacon), a terminal multiplexer that needs to deliver retired-line content to late-attaching browser clients so xterm.js's scrollback shows what the agent emitted before attach. Without `Scrollback.Render()` the multiplexer either re-implements `renderLine` (the maintenance hazard above) or ships a vendored fork of vt — neither great.

## Steps to showcase

**Before** — the only way to render retired lines was to walk cells:

```go
e := vt.NewEmulator(20, 5)
for i := 0; i < 10; i++ { e.WriteString("scrolled\r\n") }
sb := e.Scrollback()
// No Render() — caller must walk sb.CellAt(x, y) for every (x, y)
// and replicate vt's renderLine logic outside the package.
```

**After** — one call, encoding stays in lock-step with `Buffer.Render()`:

```go
e := vt.NewEmulator(20, 5)
for i := 0; i < 10; i++ { e.WriteString("scrolled\r\n") }
out := e.Scrollback().Render()
// out: "scrolled\nscrolled\n...\nscrolled" (LF-separated, no trailing LF)
```

## Tests

Five subtests added under `TestScrollback`:

1. `Render returns empty string when scrollback is empty` — empty `Scrollback`, returns `""`.
2. `Render returns empty string on nil receiver` — nil-safe.
3. `Render emits content from scrolled-off lines` — content is preserved through retirement → render.
4. `Render preserves order from oldest to newest` — earliest line appears before latest in the output.
5. `Render separates lines with newline and no trailing newline` — pins the LF-only contract (no CR, no trailing LF), matching `Lines.Render` and `Buffer.Render` upstream.

All existing `vt` tests continue to pass.

## Notes for maintainers

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

I'd usually open a Discussion first per the new-feature workflow, but the patch is minimal (~6 LOC of production code, all delegating to existing public API) and addresses an obvious gap relative to `Buffer.Render()`. Happy to convert this into a Discussion thread instead if you'd prefer — just let me know.

> When contributing to this project, you must agree that you have authored 100% of the content, (or) that you have the necessary rights to the content and that the content you contribute may be provided under the projects MIT license.

Confirmed.