### PR TITLE
fix(powernap): handle leading slash in Windows file URI paths

### DIFF
--- a/powernap/pkg/lsp/protocol/uri.go
+++ b/powernap/pkg/lsp/protocol/uri.go
@@ -114,10 +114,13 @@ slow:
 	if u.Scheme != fileScheme {
 		return "", fmt.Errorf("only file URIs are supported, got %q from %q", u.Scheme, uri)
 	}
-	// If the URI is a Windows URI, we trim the leading "/" and uppercase
-	// the drive letter, which will never be case sensitive.
-	if isWindowsDrivePath(u.Path) {
-		u.Path = strings.ToUpper(string(u.Path[1])) + u.Path[2:]
+	// If the URI is a Windows URI, trim the leading "/" and uppercase
+	// the drive letter (which is never case sensitive). url.URL.Path
+	// stores Windows file URIs in /C:/foo form, with a leading slash
+	// that hides the drive letter from isWindowsDrivePath; trim it
+	// before consulting the helper.
+	if trimmed := strings.TrimPrefix(u.Path, "/"); isWindowsDrivePath(trimmed) {
+		u.Path = strings.ToUpper(string(trimmed[0])) + trimmed[1:]
 	}
 
 	return u.Path, nil

--- a/powernap/pkg/lsp/protocol/uri_test.go
+++ b/powernap/pkg/lsp/protocol/uri_test.go
@@ -1,0 +1,85 @@
+package protocol
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestDocumentURIPath exercises DocumentURI.Path across the URI shapes
+// that real LSP clients send. The Windows-drive cases are the main
+// thing being locked in: previously DocumentURI("file:///C:/dev/foo").Path()
+// returned "\C:\dev\foo" (with a stray leading separator) because the
+// drive-letter check in filename() never matched the "/C:/..." form
+// produced by url.URL.Path.
+func TestDocumentURIPath(t *testing.T) {
+	type testCase struct {
+		name string
+		uri  DocumentURI
+		// want is the expected path in forward-slash form. The test
+		// converts it via filepath.FromSlash before comparing, so a
+		// case can express "C:/dev/foo" once and have it match
+		// "C:\dev\foo" on Windows and "C:/dev/foo" on POSIX.
+		want string
+	}
+	cases := []testCase{
+		{name: "empty", uri: "", want: ""},
+		{name: "POSIX absolute", uri: "file:///home/sven/foo.go", want: "/home/sven/foo.go"},
+		{name: "POSIX with space", uri: "file:///home/sven/My%20Code/foo.go", want: "/home/sven/My Code/foo.go"},
+	}
+	if runtime.GOOS == "windows" {
+		// Windows-only: the drive-path normalization runs through
+		// filepath.VolumeName, which only recognizes drive letters on
+		// Windows. On POSIX, "C:/dev/foo" comes back as "/C:/dev/foo"
+		// because there's no notion of a drive there - which is fine
+		// for callers, because a POSIX host will never be asked to
+		// open such a path anyway.
+		cases = append(
+			cases,
+			testCase{name: "Windows drive", uri: "file:///C:/dev/foo", want: "C:/dev/foo"},
+			testCase{name: "Windows drive lowercase", uri: "file:///c:/dev/foo", want: "C:/dev/foo"},
+			testCase{name: "Windows drive percent-encoded colon", uri: "file:///C%3A/dev/foo", want: "C:/dev/foo"},
+			testCase{name: "Windows drive with space", uri: "file:///C:/Program%20Files/foo.exe", want: "C:/Program Files/foo.exe"},
+		)
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.uri.Path()
+			if err != nil {
+				t.Fatalf("Path() error: %v", err)
+			}
+			want := filepath.FromSlash(tc.want)
+			if got != want {
+				t.Errorf("Path() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// TestDocumentURIRoundTrip checks that URIFromPath and DocumentURI.Path
+// are inverses for the path shapes the public API supports.
+func TestDocumentURIRoundTrip(t *testing.T) {
+	var paths []string
+	if runtime.GOOS == "windows" {
+		paths = []string{
+			`C:\dev\foo`,
+			`C:\Program Files\foo.exe`,
+		}
+	} else {
+		paths = []string{
+			"/home/sven/foo.go",
+			"/tmp/My Code/foo.go",
+		}
+	}
+	for _, p := range paths {
+		t.Run(p, func(t *testing.T) {
+			got, err := URIFromPath(p).Path()
+			if err != nil {
+				t.Fatalf("URIFromPath(%q).Path() error: %v", p, err)
+			}
+			if got != p {
+				t.Errorf("round-trip: got %q, want %q", got, p)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I've been running into issues with LSPs on windows in Crush.  This small PR would fix the LSP/windows bugs I'm seeing atm, I think.

As best as I can tell, the basic problem is that the existing code does not account for the fact that the windows drive letter will usually be *prefixed* by a `/`, so the current logic isn't working as intended, because it sees a path that starts with `/`, and assumes it's not actually dealing with a windows path.

Opus-4.7 wrote a little fix for me.  It also added protocol/uri_test.go (the package previously had no test file). Cases cover empty, POSIX absolute, POSIX with %20, plus four Windows-drive shapes that real LSP clients send: bare drive, lowercase drive (must uppercase), percent-encoded colon (`C%3A`), and a path with a space. Without this fix, all four Windows-drive cases fail with a leading `\` on the result.

💘 Generated with Crush

Assisted-by: Claude Opus 4.7 via Crush <crush@charm.land>

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ NA ] I have created a discussion that was approved by a maintainer (for new features).
