### PR TITLE
ansi: document that StringWidth treats tabs as zero width

### DIFF
--- a/ansi/width.go
+++ b/ansi/width.go
@@ -62,6 +62,12 @@ func Strip(s string) string {
 // codes are ignored and wide characters (such as East Asians and emojis) are
 // accounted for.
 // This treats the text as a sequence of grapheme clusters.
+//
+// C0 control characters (including tab '\t', newline '\n', and other bytes
+// below 0x20) have an undefined display width and are counted as 0. If your
+// input may contain tabs, expand them yourself before measuring, e.g.
+//
+//	w := ansi.StringWidth(strings.ReplaceAll(s, "\t", "    "))
 func StringWidth(s string) int {
 	return stringWidth(GraphemeWidth, s)
 }
@@ -71,6 +77,9 @@ func StringWidth(s string) int {
 // codes are ignored and wide characters (such as East Asians and emojis) are
 // accounted for.
 // This treats the text as a sequence of wide characters and runes.
+//
+// See [StringWidth] for the same caveat about tabs and other C0 control
+// characters being counted as zero-width.
 func StringWidthWc(s string) int {
 	return stringWidth(WcWidth, s)
 }


### PR DESCRIPTION
Closes #644.

`ansi.StringWidth(\"\t\")` returns 0 because tab is a C0 control character whose display width depends on terminal tabstop settings the package can't know about. That's intentional but unexpected if you're feeding raw user input through it. @aymanbagabas confirmed in the issue thread that this is by design and suggested a doc note with a `strings.ReplaceAll` example, so that's what this does. Same caveat noted on `StringWidthWc`.