### PR TITLE
fix(ansi): emit DECSWT/DECSIN with correct OSC numbers and ST

### DIFF
--- a/ansi/title.go
+++ b/ansi/title.go
@@ -33,16 +33,18 @@ func SetWindowTitle(s string) string {
 
 // DECSWT is a sequence for setting the window title.
 //
-// This is an alias for [SetWindowTitle]("1;<name>").
+//	OSC 21 ; name ST
+//
 // See: EK-VT520-RM 5–156 https://vt100.net/dec/ek-vt520-rm.pdf
 func DECSWT(name string) string {
-	return SetWindowTitle("1;" + name)
+	return "\x1b]21;" + name + "\x1b\\"
 }
 
 // DECSIN is a sequence for setting the icon name.
 //
-// This is an alias for [SetWindowTitle]("L;<name>").
+//	OSC 2L ; name ST
+//
 // See: EK-VT520-RM 5–134 https://vt100.net/dec/ek-vt520-rm.pdf
 func DECSIN(name string) string {
-	return SetWindowTitle("L;" + name)
+	return "\x1b]2L;" + name + "\x1b\\"
 }

--- a/ansi/title_test.go
+++ b/ansi/title_test.go
@@ -23,3 +23,17 @@ func TestSetWindowTitle(t *testing.T) {
 		t.Errorf("expected: %q, got: %q", "\x1b]2;hello\x07", ansi.SetWindowTitle("hello"))
 	}
 }
+
+func TestDECSWT(t *testing.T) {
+	want := "\x1b]21;hello\x1b\\"
+	if got := ansi.DECSWT("hello"); got != want {
+		t.Errorf("expected: %q, got: %q", want, got)
+	}
+}
+
+func TestDECSIN(t *testing.T) {
+	want := "\x1b]2L;hello\x1b\\"
+	if got := ansi.DECSIN("hello"); got != want {
+		t.Errorf("expected: %q, got: %q", want, got)
+	}
+}


### PR DESCRIPTION
\`DECSWT\` was producing \`OSC 2;1;name ST\` because it prepended \`1;\` onto \`SetWindowTitle\` (which is \`OSC 2\`). The spec is \`OSC 21\`. Same shape on \`DECSIN\`: was \`OSC 2;L;name\`, should be \`OSC 2L;name\`.

While I was here I also switched the terminator from \`BEL\` to \`ST\` (\`ESC \\\`) since that's what the EK-VT520 reference specifies. Modern emulators accept either, but a real VT520/VT525 keeps eating the title until it sees an \`ESC\`.

Sequences cross-checked against the EK-VT520-RM that the docs link to, sections 5–156 and 5–134. Added tests for both.

Closes #813.