### PR TITLE
fix(vt): store osc 8 hyperlink params and uri in correct fields

### DIFF
--- a/vt/osc.go
+++ b/vt/osc.go
@@ -131,6 +131,8 @@ func (e *Emulator) handleHyperlink(cmd int, data []byte) {
 		return
 	}
 
-	e.scr.cur.Link.URL = string(parts[1])
-	e.scr.cur.Link.Params = string(parts[2])
+	// OSC 8 wire format is ESC ] 8 ; <params> ; <uri> ST.
+	// After splitting on ';' the slots are: [cmd='8', params, uri].
+	e.scr.cur.Link.Params = string(parts[1])
+	e.scr.cur.Link.URL = string(parts[2])
 }

--- a/vt/osc.go
+++ b/vt/osc.go
@@ -131,8 +131,6 @@ func (e *Emulator) handleHyperlink(cmd int, data []byte) {
 		return
 	}
 
-	// OSC 8 wire format is ESC ] 8 ; <params> ; <uri> ST.
-	// After splitting on ';' the slots are: [cmd='8', params, uri].
 	e.scr.cur.Link.Params = string(parts[1])
 	e.scr.cur.Link.URL = string(parts[2])
 }

--- a/vt/osc_test.go
+++ b/vt/osc_test.go
@@ -1,0 +1,48 @@
+package vt
+
+import "testing"
+
+// OSC 8 wire format per https://gist.github.com/egmontkov/eb6100b9 is
+// ESC ] 8 ; <params> ; <uri> ST. handleHyperlink must store the
+// <params> segment in Link.Params and the <uri> segment in Link.URL.
+// Prior to the fix in this commit the two were swapped: Link.URL
+// received parts[1] (params) and Link.Params received parts[2] (uri),
+// which produced visible-but-unclickable links once Buffer.Render()
+// emitted them back out via ansi.SetHyperlink(URL, Params).
+func TestHandleHyperlink_StoresURLAndParamsInCorrectFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty params, populated uri (common case)", func(t *testing.T) {
+		t.Parallel()
+		term := newTestTerminal(t, 80, 24)
+		// Feed an OSC 8 open + a single character + OSC 8 close so the
+		// open's Link metadata sticks on the cell.
+		_, _ = term.Write([]byte("\x1b]8;;https://example.com/\x1b\\X\x1b]8;;\x1b\\"))
+		cell := term.CellAt(0, 0)
+		if cell == nil {
+			t.Fatal("cell at (0,0) is nil")
+		}
+		if got, want := cell.Link.URL, "https://example.com/"; got != want {
+			t.Errorf("Link.URL = %q, want %q", got, want)
+		}
+		if got, want := cell.Link.Params, ""; got != want {
+			t.Errorf("Link.Params = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("populated params and uri", func(t *testing.T) {
+		t.Parallel()
+		term := newTestTerminal(t, 80, 24)
+		_, _ = term.Write([]byte("\x1b]8;id=42:tag=demo;https://example.com/path?x=1\x1b\\X\x1b]8;;\x1b\\"))
+		cell := term.CellAt(0, 0)
+		if cell == nil {
+			t.Fatal("cell at (0,0) is nil")
+		}
+		if got, want := cell.Link.URL, "https://example.com/path?x=1"; got != want {
+			t.Errorf("Link.URL = %q, want %q", got, want)
+		}
+		if got, want := cell.Link.Params, "id=42:tag=demo"; got != want {
+			t.Errorf("Link.Params = %q, want %q", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`handleHyperlink` stores the OSC 8 params slot into `Link.URL` and the URI slot into `Link.Params`. The two fields are swapped.

## Problem

[OSC 8 wire format](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda):

```
ESC ] 8 ; <params> ; <uri> ST
```

After `bytes.Split(data, ';')` on valid `8;<params>;<uri>` input, `parts[1]` is `<params>` and `parts[2]` is `<uri>`. The handler does the opposite.

## Impact

Any consumer that round-trips cells back to ANSI via `ansi.SetHyperlink(cell.Link.URL, cell.Link.Params)` re-emits with the slots swapped. The common case `ESC]8;;<uri>ST` becomes `ESC]8;<uri>;ST` — URI in the params slot, URI slot empty. xterm.js's parser rejects it via the empty-URI branch; the styled text renders but is not clickable.

In-repo: `cellbuf` follows this exact pattern at
[screen.go:734](https://github.com/charmbracelet/x/blob/main/cellbuf/screen.go#L734),
[wrap.go:90](https://github.com/charmbracelet/x/blob/main/cellbuf/wrap.go#L90),
[pen.go:66](https://github.com/charmbracelet/x/blob/main/cellbuf/pen.go#L66),
[writer.go:126](https://github.com/charmbracelet/x/blob/main/cellbuf/writer.go#L126),
so any `cellbuf` consumer whose cells were populated by `vt` inherits the swap.

Common emitters of OSC 8 whose output would round-trip incorrectly:
GNU coreutils [`ls --hyperlink`](https://git.savannah.gnu.org/cgit/coreutils.git/commit/?id=799bac0d06cfabe9491498727308df8d1aca6d98),
[ripgrep](https://github.com/BurntSushi/ripgrep/pull/2322),
[fd](https://github.com/sharkdp/fd/pull/1571).

## Changes

`vt/osc.go`: swap the two assignments.
`vt/osc_test.go` (new): two subtests via `Emulator.CellAt(0,0).Link`,
covering empty-params and populated-params forms. Both fail on `main`
with field-value assertions surfacing the swap; pass with the fix.

## Testing

`go test -race ./vt/...` passes locally; CI covers Linux/macOS/Windows.
