### PR TITLE
feat(charmtone): add NameFromHex for reverse hex-to-name lookup

### DIFF
--- a/exp/charmtone/charmtone.go
+++ b/exp/charmtone/charmtone.go
@@ -6,6 +6,9 @@ import (
 	"image/color"
 	"slices"
 	"strconv"
+	"strings"
+	"sync"
+	"unicode/utf8"
 )
 
 var _ color.Color = Key(0)
@@ -441,3 +444,36 @@ const Charcoal = Char
 // Ash is an alias for Sash.
 // Deprecated: Ash has been renamed to [Sash].
 const Ash = Sash
+
+// hexToName maps uppercase hex values (e.g. "#6B50FF") to their canonical
+// CharmTone name. Built lazily on first use.
+var (
+	hexToName     map[string]string
+	hexToNameOnce sync.Once
+)
+
+func getHexToName() map[string]string {
+	hexToNameOnce.Do(func() {
+		hexToName = make(map[string]string, len(colors))
+		for _, k := range Keys() {
+			hexToName[k.Hex()] = k.String()
+		}
+	})
+	return hexToName
+}
+
+// NameFromHex returns the canonical CharmTone name for the given hex
+// color string, or empty string if no match. The lookup is
+// case-insensitive and accepts "#rrggbb" format.
+func NameFromHex(hex string) string {
+	r, size := utf8.DecodeRuneInString(hex)
+	if r != '#' || size == 0 {
+		return ""
+	}
+	rest := hex[size:]
+	if len(rest) != 6 {
+		return ""
+	}
+	upper := "#" + strings.ToUpper(rest)
+	return getHexToName()[upper]
+}

--- a/exp/charmtone/charmtone_test.go
+++ b/exp/charmtone/charmtone_test.go
@@ -17,3 +17,46 @@ func TestValidateHexes(t *testing.T) {
 		}
 	}
 }
+
+func TestNameFromHex(t *testing.T) {
+	for _, key := range Keys() {
+		name := NameFromHex(key.Hex())
+		if name != key.String() {
+			t.Errorf("NameFromHex(%q) = %q, want %q", key.Hex(), name, key.String())
+		}
+	}
+}
+
+func TestNameFromHex_CaseInsensitive(t *testing.T) {
+	tests := []struct {
+		hex  string
+		want string
+	}{
+		{"#6b50ff", "Charple"},
+		{"#6B50FF", "Charple"},
+		{"#6B50Ff", "Charple"},
+		{"#201f26", "Pepper"},
+		{"#ecebf0", "Sash"},
+	}
+	for _, tt := range tests {
+		got := NameFromHex(tt.hex)
+		if got != tt.want {
+			t.Errorf("NameFromHex(%q) = %q, want %q", tt.hex, got, tt.want)
+		}
+	}
+}
+
+func TestNameFromHex_NoMatch(t *testing.T) {
+	tests := []string{
+		"#000000",
+		"#FFFFFF",
+		"",
+		"not-a-hex",
+		"#FFF",
+	}
+	for _, hex := range tests {
+		if got := NameFromHex(hex); got != "" {
+			t.Errorf("NameFromHex(%q) = %q, want empty", hex, got)
+		}
+	}
+}


### PR DESCRIPTION
Add `NameFromHex` for case-insensitive reverse lookup from hex color strings to canonical CharmTone names (e.g. `"#6b50ff"` → `"Charple"`). Returns empty string when no match is found.

The internal map is built lazily via `sync.Once` and keyed on uppercase hex to normalize input.


💘 Generated with Crush