### PR TITLE
fix(vt): use atomic.Bool for Emulator.closed to prevent data race

### DIFF
--- a/vt/emulator.go
+++ b/vt/emulator.go
@@ -3,6 +3,7 @@ package vt
 import (
 	"image/color"
 	"io"
+	"sync/atomic"
 
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/ultraviolet/screen"
@@ -68,7 +69,7 @@ type Emulator struct {
 	gsingle int // temporarily select GL or GR
 
 	// Indicates if the terminal is closed.
-	closed bool
+	closed atomic.Bool
 
 	// atPhantom indicates if the cursor is out of bounds.
 	// When true, and a character is written, the cursor is moved to the next line.
@@ -249,7 +250,7 @@ func (e *Emulator) Resize(width int, height int) {
 
 // Read reads data from the terminal input buffer.
 func (e *Emulator) Read(p []byte) (n int, err error) {
-	if e.closed {
+	if e.closed.Load() {
 		return 0, io.EOF
 	}
 
@@ -258,17 +259,16 @@ func (e *Emulator) Read(p []byte) (n int, err error) {
 
 // Close closes the terminal.
 func (e *Emulator) Close() error {
-	if e.closed {
+	if e.closed.Swap(true) {
 		return nil
 	}
 
-	e.closed = true
 	return e.pw.CloseWithError(io.EOF) //nolint:wrapcheck
 }
 
 // Write writes data to the terminal output buffer.
 func (e *Emulator) Write(p []byte) (n int, err error) {
-	if e.closed {
+	if e.closed.Load() {
 		return 0, io.ErrClosedPipe
 	}
 

--- a/vt/emulator_close_test.go
+++ b/vt/emulator_close_test.go
@@ -1,0 +1,84 @@
+package vt
+
+import (
+	"io"
+	"sync"
+	"testing"
+)
+
+func TestEmulatorCloseDataRace(t *testing.T) {
+	emu := NewEmulator(80, 24)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine 1: Read (blocks on pipe)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 1024)
+		n, err := emu.Read(buf)
+		if err != io.EOF {
+			t.Errorf("expected io.EOF, got n=%d err=%v", n, err)
+		}
+	}()
+
+	// Goroutine 2: Close (should unblock Read)
+	go func() {
+		defer wg.Done()
+		if err := emu.Close(); err != nil {
+			t.Errorf("unexpected close error: %v", err)
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestSafeEmulatorCloseDataRace(t *testing.T) {
+	emu := NewSafeEmulator(80, 24)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 1024)
+		n, err := emu.Read(buf)
+		if err != io.EOF {
+			t.Errorf("expected io.EOF, got n=%d err=%v", n, err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		if err := emu.Close(); err != nil {
+			t.Errorf("unexpected close error: %v", err)
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestEmulatorCloseIdempotent(t *testing.T) {
+	emu := NewEmulator(80, 24)
+
+	if err := emu.Close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+
+	if err := emu.Close(); err != nil {
+		t.Fatalf("second close should be no-op: %v", err)
+	}
+}
+
+func TestEmulatorWriteAfterClose(t *testing.T) {
+	emu := NewEmulator(80, 24)
+
+	if err := emu.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	n, err := emu.Write([]byte("hello"))
+	if err != io.ErrClosedPipe {
+		t.Errorf("expected ErrClosedPipe, got n=%d err=%v", n, err)
+	}
+}


### PR DESCRIPTION
## Description

Fixes a data race on `Emulator.closed` between `Read()` and `Close()`.

**Problem:** `Emulator.Read` reads `closed` (line 252) then blocks on the pipe. `Emulator.Close` writes `closed = true` (line 265) to unblock it. Both accesses are unsynchronized — `go test -race` flags this as a data race. `SafeEmulator.Read` deliberately holds no lock (so it can block without holding the mutex), and there's no `SafeEmulator.Close` override, so the race also exists through the safe wrapper.

**Fix:** Replace `closed bool` with `sync/atomic.Bool`:
- `Read()`: `closed.Load()` — lock-free check before blocking on the pipe
- `Close()`: `closed.Swap(true)` — atomic check-and-set (returns early if already closed)
- `Write()`: `closed.Load()` — lock-free check before writing

No mutex needs to be held across the blocking read, which is the whole point of `SafeEmulator.Read` not taking the lock.

**Testing:** Added `TestEmulatorCloseDataRace` and `TestSafeEmulatorCloseDataRace` which exercise the concurrent Read+Close pattern with `go test -race`. All existing tests pass.

Fixes #879