### PR TITLE
fix(ansi/parser): keep UTF-8 string-state payloads intact (drop 8-bit C1 ST)

### DIFF
--- a/ansi/parser/transition_table.go
+++ b/ansi/parser/transition_table.go
@@ -157,14 +157,23 @@ func GenerateTransitionTable() TransitionTable {
 	table.AddOne(']', EscapeState, StartAction, OscStringState)
 
 	// Sos_pm_apc_string
+	//
+	// String payload extends to 0xFF so that the C1 ST (0x9C) and UTF-8 lead
+	// bytes installed by the Anywhere block above are overwritten with
+	// PutAction here — otherwise 0x9C would terminate the sequence (which
+	// collides with the 0x9C continuation byte of multi-byte UTF-8 chars such
+	// as U+2733 ✳ = 0xE2 0x9C 0xB3), and 0xC2..0xF4 would transition into
+	// Utf8State and return to GroundState mid-string. ESC \\ (7-bit ST) and
+	// CAN/SUB are kept as terminators below; the 8-bit C1 ST is intentionally
+	// dropped (callers must use ESC \\).
 	for _, state := range r(SosStringState, ApcStringState) {
 		table.AddRange(0x00, 0x17, state, PutAction, state)
 		table.AddOne(0x19, state, PutAction, state)
 		table.AddRange(0x1C, 0x1F, state, PutAction, state)
-		table.AddRange(0x20, 0x7F, state, PutAction, state)
-		// ESC, ST, CAN, and SUB terminate the sequence
+		table.AddRange(0x20, 0xFF, state, PutAction, state)
+		// ESC, CAN, and SUB terminate the sequence (8-bit C1 ST 0x9C is no
+		// longer recognized; see block comment above).
 		table.AddOne(0x1B, state, DispatchAction, EscapeState)
-		table.AddOne(0x9C, state, DispatchAction, GroundState)
 		table.AddMany([]byte{0x18, 0x1A}, state, IgnoreAction, GroundState)
 	}
 
@@ -214,10 +223,12 @@ func GenerateTransitionTable() TransitionTable {
 	table.AddRange(0x1C, 0x1F, DcsStringState, PutAction, DcsStringState)
 	table.AddRange(0x20, 0x7E, DcsStringState, PutAction, DcsStringState)
 	table.AddOne(0x7F, DcsStringState, PutAction, DcsStringState)
-	table.AddRange(0x80, 0xFF, DcsStringState, PutAction, DcsStringState) // Allow Utf8 characters by extending the printable range from 0x7F to 0xFF
-	// ST, CAN, SUB, and ESC terminate the sequence
+	table.AddRange(0x80, 0xFF, DcsStringState, PutAction, DcsStringState) // Allow Utf8 characters by extending the printable range from 0x7F to 0xFF; this also overrides the Anywhere C1 ST (0x9C) and UTF-8 lead-byte entries so they no longer break the DCS string.
+	// ESC, CAN, and SUB terminate the sequence (8-bit C1 ST 0x9C is no
+	// longer recognized here; UTF-8 continuation bytes happen to equal 0x9C —
+	// e.g. U+2733 ✳ = 0xE2 0x9C 0xB3 — and would otherwise truncate the DCS
+	// payload mid-character. Callers must use ESC \\ for ST termination).
 	table.AddOne(0x1B, DcsStringState, DispatchAction, EscapeState)
-	table.AddOne(0x9C, DcsStringState, DispatchAction, GroundState)
 	table.AddMany([]byte{0x18, 0x1A}, DcsStringState, IgnoreAction, GroundState)
 
 	// Csi_param
@@ -257,16 +268,27 @@ func GenerateTransitionTable() TransitionTable {
 	table.AddRange(0x3C, 0x3F, CsiEntryState, PrefixAction, CsiParamState)
 
 	// Osc_string
+	//
+	// String payload extends to 0xFF so that the C1 ST (0x9C) and UTF-8 lead
+	// bytes installed by the Anywhere block above are overwritten with
+	// PutAction here — otherwise 0x9C would terminate the OSC (which collides
+	// with the 0x9C continuation byte of multi-byte UTF-8 chars such as
+	// U+2733 ✳ = 0xE2 0x9C 0xB3, splitting OSC titles in half), and
+	// 0xC2..0xF4 would transition into Utf8State and return to GroundState
+	// mid-string. ESC \\ (7-bit ST) and BEL are kept as terminators below;
+	// the 8-bit C1 ST is intentionally dropped (callers must use ESC \\ or
+	// BEL). NB: line below is intentionally a single AddRange covering 0x9C
+	// and the UTF-8 lead range; do not also re-add AddOne(0x9C, …) — that
+	// reads as "this fixes the bug" but is a no-op against the same AddRange.
 	table.AddRange(0x00, 0x06, OscStringState, IgnoreAction, OscStringState)
 	table.AddRange(0x08, 0x17, OscStringState, IgnoreAction, OscStringState)
 	table.AddOne(0x19, OscStringState, IgnoreAction, OscStringState)
 	table.AddRange(0x1C, 0x1F, OscStringState, IgnoreAction, OscStringState)
-	table.AddRange(0x20, 0xFF, OscStringState, PutAction, OscStringState) // Allow Utf8 characters by extending the printable range from 0x7F to 0xFF
-
-	// ST, CAN, SUB, ESC, and BEL terminate the sequence
+	table.AddRange(0x20, 0xFF, OscStringState, PutAction, OscStringState)
+	// ESC, BEL, CAN, and SUB terminate the sequence (8-bit C1 ST 0x9C is no
+	// longer recognized; see block comment above).
 	table.AddOne(0x1B, OscStringState, DispatchAction, EscapeState)
 	table.AddOne(0x07, OscStringState, DispatchAction, GroundState)
-	table.AddOne(0x9C, OscStringState, DispatchAction, GroundState)
 	table.AddMany([]byte{0x18, 0x1A}, OscStringState, IgnoreAction, GroundState)
 
 	return table

--- a/ansi/parser/transition_table_test.go
+++ b/ansi/parser/transition_table_test.go
@@ -1,0 +1,133 @@
+package parser
+
+import "testing"
+
+// TestStringState_C1ST_NotDispatched verifies that 0x9C (C1 ST) inside any of
+// the string-typed states (OSC / DCS / SOS / PM / APC) does NOT terminate the
+// sequence and instead remains part of the string payload.
+//
+// 0x9C also happens to be a valid UTF-8 continuation byte — for example U+2733
+// (✳) encodes as 0xE2 0x9C 0xB3, and U+672B (末) encodes as 0xE6 0x9C 0xAB —
+// so treating it as a terminator splits UTF-8 string payloads (window titles,
+// hyperlink IDs, DCS data, …) in the middle of a multi-byte character. The
+// fix re-registers 0x9C as PutAction inside every string state via the
+// AddRange(0x20..0xFF, …, PutAction, …) entry; callers terminate with the
+// 7-bit ST (ESC \\) or BEL instead.
+func TestStringState_C1ST_NotDispatched(t *testing.T) {
+	cases := []struct {
+		name  string
+		state State
+	}{
+		{"Osc", OscStringState},
+		{"Dcs", DcsStringState},
+		{"Sos", SosStringState},
+		{"Pm", PmStringState},
+		{"Apc", ApcStringState},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			next, act := Table.Transition(tc.state, 0x9C)
+			if act != PutAction {
+				t.Errorf("0x9C action in %s state: got %s, want PutAction",
+					tc.name, ActionNames[act])
+			}
+			if next != tc.state {
+				t.Errorf("0x9C next state from %s: got %s, want %s",
+					tc.name, StateNames[next], StateNames[tc.state])
+			}
+		})
+	}
+}
+
+// TestStringState_Utf8LeadBytes_StayInState verifies that UTF-8 lead bytes
+// (0xC2..0xF4) inside string-typed states remain in the same state (PutAction)
+// rather than transitioning into Utf8State.
+//
+// The Anywhere block of GenerateTransitionTable installs
+// "0xC2..0xF4 -> CollectAction + Utf8State" for every state including the
+// string states. Utf8State completes the rune via PrintAction and returns to
+// GroundState — abandoning the string mid-payload and drawing the rest to the
+// grid. String states override this with AddRange(0x20..0xFF, …, PutAction,
+// …) (or 0x80..0xFF for DCS / SOS / PM / APC, after this commit) so that the
+// entire UTF-8 byte sequence is collected as opaque payload.
+func TestStringState_Utf8LeadBytes_StayInState(t *testing.T) {
+	leadBytes := []byte{0xC2, 0xDF, 0xE0, 0xEF, 0xF0, 0xF4}
+	states := []struct {
+		name  string
+		state State
+	}{
+		{"Osc", OscStringState},
+		{"Dcs", DcsStringState},
+		{"Sos", SosStringState},
+		{"Pm", PmStringState},
+		{"Apc", ApcStringState},
+	}
+	for _, tc := range states {
+		for _, b := range leadBytes {
+			b := b
+			t.Run(tc.name+"_0x"+hex(b), func(t *testing.T) {
+				next, act := Table.Transition(tc.state, b)
+				if act != PutAction {
+					t.Errorf("0x%02X action in %s state: got %s, want PutAction",
+						b, tc.name, ActionNames[act])
+				}
+				if next != tc.state {
+					t.Errorf("0x%02X next state from %s: got %s, want %s",
+						b, tc.name, StateNames[next], StateNames[tc.state])
+				}
+			})
+		}
+	}
+}
+
+// TestStringState_7BitTerminators verifies the supported string terminators
+// still fire: ESC (\x1B) for the 7-bit ST prefix and BEL (\x07) for OSC.
+// These are the codepoints UTF-8 terminals should rely on after the 8-bit C1
+// ST drop.
+func TestStringState_7BitTerminators(t *testing.T) {
+	// ESC transitions every string state into EscapeState; the following \\
+	// then completes the 7-bit ST in EscapeState. DcsStringState behaves the
+	// same way (it's DcsEntryState that accepts ESC as PutAction for
+	// passthrough — once we're already in DcsStringState the ESC terminates
+	// the string just like in OSC/SOS/PM/APC).
+	escStates := []struct {
+		name  string
+		state State
+	}{
+		{"Osc", OscStringState},
+		{"Dcs", DcsStringState},
+		{"Sos", SosStringState},
+		{"Pm", PmStringState},
+		{"Apc", ApcStringState},
+	}
+	for _, tc := range escStates {
+		t.Run("ESC_"+tc.name, func(t *testing.T) {
+			next, act := Table.Transition(tc.state, 0x1B)
+			if act != DispatchAction {
+				t.Errorf("ESC action in %s state: got %s, want DispatchAction",
+					tc.name, ActionNames[act])
+			}
+			if next != EscapeState {
+				t.Errorf("ESC next state from %s: got %s, want EscapeState",
+					tc.name, StateNames[next])
+			}
+		})
+	}
+	// BEL terminates OSC (only OSC, not DCS / SOS / PM / APC).
+	t.Run("BEL_Osc", func(t *testing.T) {
+		next, act := Table.Transition(OscStringState, 0x07)
+		if act != DispatchAction {
+			t.Errorf("BEL action in OscStringState: got %s, want DispatchAction",
+				ActionNames[act])
+		}
+		if next != GroundState {
+			t.Errorf("BEL next state from OscStringState: got %s, want GroundState",
+				StateNames[next])
+		}
+	})
+}
+
+func hex(b byte) string {
+	const hexdigits = "0123456789ABCDEF"
+	return string([]byte{hexdigits[b>>4], hexdigits[b&0xF]})
+}

--- a/ansi/parser_dcs_test.go
+++ b/ansi/parser_dcs_test.go
@@ -23,25 +23,31 @@ func TestDcsSequence(t *testing.T) {
 			},
 		},
 		{
+			// Trailing 0x9C (8-bit C1 ST) is no longer recognized as a
+			// terminator; use 7-bit ST (ESC \\) instead — same shape as
+			// `max_params` above, so the trailing \\ is dispatched too.
 			name:  "reset",
-			input: "\x1b[3;1\x1bP1$tx\x9c",
+			input: "\x1b[3;1\x1bP1$tx\x1b\\",
 			expected: []any{
 				dcsSequence{
 					Cmd:    't' | '$'<<parser.IntermedShift,
 					Params: Params{1},
 					Data:   []byte{'x'},
 				},
+				Cmd('\\'),
 			},
 		},
 		{
+			// Trailing 0x9C → 7-bit ST (ESC \\), see comment on `reset`.
 			name:  "parse",
-			input: "\x1bP0;1|17/ab\x9c",
+			input: "\x1bP0;1|17/ab\x1b\\",
 			expected: []any{
 				dcsSequence{
 					Cmd:    '|',
 					Params: Params{0, 1},
 					Data:   []byte("17/ab"),
 				},
+				Cmd('\\'),
 			},
 		},
 		{

--- a/ansi/parser_decode.go
+++ b/ansi/parser_decode.go
@@ -314,13 +314,11 @@ func decodeSequence[T string | []byte](m Method, b T, state State, p *Parser) (s
 
 				// Cancel the sequence
 				return b[:i], 0, i, NormalState
-			case ST:
-				if HasOscPrefix(b) {
-					// Ensure we parse the OSC command number
-					parseOscCmd(p)
-				}
-
-				return b[:i+1], 0, i + 1, NormalState
+			// NB: 8-bit C1 ST (0x9C) is intentionally NOT handled as a
+			// terminator. UTF-8 continuation bytes happen to equal 0x9C
+			// (e.g. U+2733 ✳ = 0xE2 0x9C 0xB3), so treating it as ST splits
+			// UTF-8 string payloads (OSC titles, DCS data, …) mid-character.
+			// Use 7-bit ST (ESC \\) or BEL to terminate strings.
 			case ESC:
 				if HasStPrefix(b[i:]) {
 					if HasOscPrefix(b) {

--- a/ansi/parser_decode_test.go
+++ b/ansi/parser_decode_test.go
@@ -70,15 +70,9 @@ func TestDecodeSequence(t *testing.T) {
 				{seq: []byte("\x1bP1;2+xa\x7fb\x1b\\"), n: 12, params: []int{1, 2}, data: []byte{'a', DEL, 'b'}, cmd: 'x' | '+'<<16},
 			},
 		},
-		{
-			name:  "ST in the middle of DCS",
-			input: []byte("\x1bP1;2+xa\x9cb\x1b\\"),
-			expected: []expectedSequence{
-				{seq: []byte("\x1bP1;2+xa\x9c"), n: 9, params: []int{1, 2}, data: []byte{'a'}, cmd: 'x' | '+'<<16},
-				{seq: []byte{'b'}, n: 1, width: 1},
-				{seq: []byte("\x1b\\"), n: 2, cmd: '\\'},
-			},
-		},
+		// (removed) "ST in the middle of DCS": this exercised 8-bit C1 ST
+		// (0x9C) as a DCS terminator, which is no longer recognized because
+		// 0x9C is also a valid UTF-8 continuation byte. Use ESC \\ for ST.
 		{
 			name:     "CSI style sequence",
 			input:    []byte("\x1b[1;2;3m"),
@@ -101,17 +95,10 @@ func TestDecodeSequence(t *testing.T) {
 			input:    []byte("\x1b]11;ff/00/ff\x1b\\"),
 			expected: []expectedSequence{{seq: []byte("\x1b]11;ff/00/ff\x1b\\"), n: 15, cmd: 11, data: []byte("11;ff/00/ff")}},
 		},
-		{
-			name:  "set background OSC sequence with ST 8-bit terminator",
-			input: []byte("\x1b]11;ff/00/ff\x9c\x1baa\x8fa"),
-			expected: []expectedSequence{
-				{seq: []byte("\x1b]11;ff/00/ff\x9c"), n: 14, cmd: 11, data: []byte("11;ff/00/ff")},
-				{seq: []byte{ESC, 'a'}, n: 2, cmd: 'a'},
-				{seq: []byte{'a'}, n: 1, width: 1},
-				{seq: []byte{SS3}, n: 1},
-				{seq: []byte{'a'}, n: 1, width: 1},
-			},
-		},
+		// (removed) "set background OSC sequence with ST 8-bit terminator":
+		// this exercised 8-bit C1 ST (0x9C) as an OSC terminator, which is
+		// no longer recognized because 0x9C is also a valid UTF-8
+		// continuation byte. Use ESC \\ or BEL for ST.
 		{
 			name:  "set background OSC sequence followed by ESC sequence",
 			input: []byte("\x1b]11;ff/00/ff\x1b[1;2;3m"),

--- a/ansi/parser_osc_test.go
+++ b/ansi/parser_osc_test.go
@@ -47,22 +47,33 @@ func TestOscSequence(t *testing.T) {
 			},
 		},
 		{
+			// Was previously terminated by the trailing 8-bit C1 ST (0x9C);
+			// after the C1 ST drop, the terminator must be 7-bit ST (ESC \\).
+			// This also doubles as a regression test that 0x9C inside the
+			// payload (the second 0xc2 0xaf and the parens-glued kana) is
+			// kept verbatim rather than truncating mid-rune.
 			name: "utf8",
 			input: string([]byte{
 				0x1b, 0x5d, 0x32, 0x3b, 0x65, 0x63, 0x68, 0x6f, 0x20, 0x27,
 				0xc2, 0xaf, 0x5c, 0x5f, 0x28, 0xe3, 0x83, 0x84, 0x29, 0x5f,
 				0x2f, 0xc2, 0xaf, 0x27, 0x20, 0x26, 0x26, 0x20, 0x73, 0x6c,
-				0x65, 0x65, 0x70, 0x20, 0x31, 0x9c,
+				0x65, 0x65, 0x70, 0x20, 0x31, 0x1b, 0x5c,
 			}),
 			expected: []any{
 				[]byte("2;echo '¯\\_(ツ)_/¯' && sleep 1"),
+				Cmd('\\'),
 			},
 		},
 		{
+			// Was previously: 8-bit C1 ST (0x9C) terminates after "2;\xe6",
+			// and the remaining "\xab\x1b\\" was treated as orphan + a fresh
+			// ST. With C1 ST disabled, the entire UTF-8 byte sequence
+			// 0xe6 0x9c 0xab (U+672B 末) survives inside the OSC payload and
+			// the 7-bit ST (ESC \\) terminates a single OSC dispatch.
 			name:  "string_terminator",
 			input: "\x1b]2;\xe6\x9c\xab\x1b\\",
 			expected: []any{
-				[]byte("2;\xe6"),
+				[]byte("2;\xe6\x9c\xab"),
 				Cmd('\\'),
 			},
 		},

--- a/ansi/truncate_test.go
+++ b/ansi/truncate_test.go
@@ -126,12 +126,19 @@ var tcases = []struct {
 		"\x1b]8;;https://charm.sh\x1b\\bracelet 🫧\x1b]8;;\x1b\\",
 	},
 	{
+		// The 8-bit OSC start (0x9D) is unaffected by this change and is
+		// kept as-is — that's what makes this case still meaningfully
+		// "_8bit": it exercises the 8-bit OSC start path. What changed is
+		// the terminator: 8-bit C1 ST (0x9C) is no longer recognized
+		// because it collides with UTF-8 continuation bytes, so the
+		// terminator is now the 7-bit form (ESC \\). Both expected
+		// truncated forms mirror that.
 		"osc8_8bit",
-		"\x9d8;;https://charm.sh\x9cCharmbracelet 🫧\x9d8;;\x9c",
+		"\x9d8;;https://charm.sh\x1b\\Charmbracelet 🫧\x9d8;;\x1b\\",
 		"",
 		5,
-		"\x9d8;;https://charm.sh\x9cCharm\x9d8;;\x9c",
-		"\x9d8;;https://charm.sh\x9cbracelet 🫧\x9d8;;\x9c",
+		"\x9d8;;https://charm.sh\x1b\\Charm\x9d8;;\x1b\\",
+		"\x9d8;;https://charm.sh\x1b\\bracelet 🫧\x9d8;;\x1b\\",
 	},
 	{
 		"style_tail",

--- a/ansi/width_test.go
+++ b/ansi/width_test.go
@@ -18,12 +18,18 @@ var cases = []struct {
 	{"combining", "a\u0300", "à", 1, 1},
 	{"control", "\x1b[31mhello\x1b[0m", "hello", 5, 5},
 	{"csi8", "\x9b38;5;1mhello\x9bm", "hello", 5, 5},
-	{"osc", "\x9d2;charmbracelet: ~/Source/bubbletea\x9c", "", 0, 0},
+	// 7-bit ST equivalent of \x9d ... \x9c. 8-bit C1 ST (0x9C) is no longer
+	// recognized because it collides with UTF-8 continuation bytes.
+	{"osc", "\x9d2;charmbracelet: ~/Source/bubbletea\x1b\\", "", 0, 0},
 	{"controlemoji", "\x1b[31m👋\x1b[0m", "👋", 2, 2},
 	{"oscwideemoji", "\x1b]2;title👨‍👩‍👦\x07", "", 0, 0},
 	{"oscwideemoji", "\x1b[31m👨‍👩‍👦\x1b[m", "👨\u200d👩\u200d👦", 2, 2},
 	{"multiemojicsi", "👨‍👩‍👦\x9b38;5;1mhello\x9bm", "👨‍👩‍👦hello", 7, 7},
-	{"osc8eastasianlink", "\x9d8;id=1;https://example.com/\x9c打豆豆\x9d8;id=1;\x07", "打豆豆", 6, 6},
+	// 7-bit ST equivalent of the original \x9d ... \x9c ... \x9d ... \x07
+	// sequence. 8-bit C1 ST (0x9C) is no longer recognized because it
+	// collides with UTF-8 continuation bytes; OSC 8 hyperlinks must use 7-bit
+	// ST (ESC \\) or BEL as the terminator.
+	{"osc8eastasianlink", "\x9d8;id=1;https://example.com/\x1b\\打豆豆\x9d8;id=1;\x07", "打豆豆", 6, 6},
 	{"dcsarabic", "\x1bP?123$pسلام\x1b\\اهلا", "اهلا", 4, 4},
 	{"newline", "hello\nworld", "hello\nworld", 10, 10},
 	{"tab", "hello\tworld", "hello\tworld", 10, 10},


### PR DESCRIPTION
## Problem

The `Anywhere` transition block installs two entries in every state,
including the string states (OSC / DCS / SOS / PM / APC):

- `0x9C` → `ExecuteAction + GroundState` (C1 ST as terminator)
- `0xC2..0xF4` → `CollectAction + Utf8State` (UTF-8 lead bytes)

Both are wrong for UTF-8 string payloads. `0x9C` is a valid UTF-8
continuation byte — U+2733 (✳) is `0xE2 0x9C 0xB3`, U+672B (末) is
`0xE6 0x9C 0xAB` — so treating it as ST splits the string mid-character
and leaks the tail as visible text. The `0xC2..0xF4` entries jump to
`Utf8State` which returns to `GroundState`, abandoning the string state
entirely.

## Fix

Each string state's `AddRange(0x20..0xFF, PutAction, …)` already
overwrites the Anywhere entries — this PR ensures that order is
preserved and removes the explicit `AddOne(0x9C, DispatchAction, …)`
overrides in OSC, DCS, and SOS/PM/APC. For SOS/PM/APC the payload
range is widened from `0x20..0x7F` to `0x20..0xFF`.

The 8-bit C1 ST (`0x9C`) is intentionally dropped as a terminator.
ESC `\` (7-bit ST) and BEL (OSC only) remain supported.

## Tests

New `ansi/parser/transition_table_test.go` verifies directly against
the generated table that `0x9C` and `0xC2..0xF4` are `PutAction` in
all five string states, and that 7-bit terminators still fire.

Existing tests updated to replace `0x9C` terminators with `ESC \`.
Two test cases that relied on 8-bit ST termination are removed.