### PR TITLE
feat(vt): add SafeEmulator.View/Update for batched locked access

### DIFF
--- a/vt/safe_emulator.go
+++ b/vt/safe_emulator.go
@@ -62,6 +62,32 @@ func (se *SafeEmulator) CellAt(x, y int) *uv.Cell {
 	return se.Emulator.CellAt(x, y)
 }
 
+// View runs fn while holding the emulator's read lock, giving it
+// direct access to the underlying Emulator for the duration. Use it
+// to batch many reads under a single lock acquisition — a renderer
+// walking the full cell grid pays one RLock here instead of a
+// per-cell RLock+defer through CellAt, which profiles as a
+// significant share of frame time in real applications (thousands of
+// lock acquisitions per frame on a large grid). fn must not retain
+// the *Emulator or any cell pointers past its return, and must not
+// call the SafeEmulator's own locking methods (deadlock).
+func (se *SafeEmulator) View(fn func(*Emulator)) {
+	se.mu.RLock()
+	defer se.mu.RUnlock()
+	fn(se.Emulator)
+}
+
+// Update is View's write-locked counterpart: fn gets exclusive
+// access to the underlying Emulator, letting callers batch many
+// mutations (e.g. replaying a snapshot cell by cell via SetCell)
+// under one lock acquisition. The same retention and reentrancy
+// rules as View apply.
+func (se *SafeEmulator) Update(fn func(*Emulator)) {
+	se.mu.Lock()
+	defer se.mu.Unlock()
+	fn(se.Emulator)
+}
+
 // SendKey sends a key event to the emulator in a concurrency-safe manner.
 func (se *SafeEmulator) SendKey(key uv.KeyEvent) {
 	se.mu.Lock()

--- a/vt/safe_emulator_view_test.go
+++ b/vt/safe_emulator_view_test.go
@@ -1,0 +1,86 @@
+package vt
+
+import (
+	"sync"
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// TestSafeEmulatorViewUpdate verifies View/Update give locked access
+// to the underlying emulator and exclude concurrent writers.
+func TestSafeEmulatorViewUpdate(t *testing.T) {
+	se := NewSafeEmulator(80, 24)
+	se.Update(func(e *Emulator) {
+		c := &uv.Cell{Content: "x", Width: 1}
+		e.SetCell(0, 0, c)
+	})
+	var got string
+	se.View(func(e *Emulator) {
+		if c := e.CellAt(0, 0); c != nil {
+			got = c.Content
+		}
+	})
+	if got != "x" {
+		t.Fatalf("View read %q, want x", got)
+	}
+}
+
+// TestSafeEmulatorViewConcurrent runs grid-walking Views against
+// concurrent Writes under -race: batched reads must be as safe as
+// per-cell CellAt.
+func TestSafeEmulatorViewConcurrent(t *testing.T) {
+	se := NewSafeEmulator(80, 24)
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_, _ = se.Write([]byte("hello world\r\n"))
+		}
+	}()
+	for range 100 {
+		se.View(func(e *Emulator) {
+			for y := 0; y < e.Height(); y++ {
+				for x := 0; x < e.Width(); x++ {
+					_ = e.CellAt(x, y)
+				}
+			}
+		})
+	}
+	close(stop)
+	wg.Wait()
+}
+
+// BenchmarkCellAtGridWalk is the per-cell locking cost View exists
+// to avoid: an 80x24 grid read through CellAt.
+func BenchmarkCellAtGridWalk(b *testing.B) {
+	se := NewSafeEmulator(80, 24)
+	for b.Loop() {
+		for y := 0; y < 24; y++ {
+			for x := 0; x < 80; x++ {
+				_ = se.CellAt(x, y)
+			}
+		}
+	}
+}
+
+// BenchmarkViewGridWalk is the same read batched under one lock.
+func BenchmarkViewGridWalk(b *testing.B) {
+	se := NewSafeEmulator(80, 24)
+	for b.Loop() {
+		se.View(func(e *Emulator) {
+			for y := 0; y < 24; y++ {
+				for x := 0; x < 80; x++ {
+					_ = e.CellAt(x, y)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`SafeEmulator.CellAt` takes an RLock (plus its deferred unlock) on **every call**. Any consumer that walks the cell grid per frame — i.e., every renderer built on vt — pays this per cell: an 80×24 grid is ~2k lock acquisitions per pass, and real applications run multiple passes per frame on much larger grids.

Profiling [xerotty](https://github.com/LXXero/xerotty) (a terminal emulator built on vt) under continuous redraw with Linux `perf`: after eliminating our own per-cell costs, `SafeEmulator.CellAt` + its defer wrapper remained the **top CPU entry at ~16% of total process time** (~15k lock+defer pairs per frame on a 240×65 grid at 20fps ≈ 300k lock ops/sec, all to read cells that cannot change mid-frame).

## Change

bbolt-style scoped accessors, purely additive:

```go
func (se *SafeEmulator) View(fn func(*Emulator))   // batched reads under one RLock
func (se *SafeEmulator) Update(fn func(*Emulator)) // batched writes under one Lock
```

Renderers wrap each frame's grid walk in one `View`; bulk mutations (e.g. replaying a snapshot via SetCell) batch under one `Update`. Existing per-call methods unchanged.

## Benchmark

An 80×24 grid walk, per-cell `CellAt` vs the same reads under one `View`:

```
BenchmarkCellAtGridWalk-16     162933    14081 ns/op
BenchmarkViewGridWalk-16      1885207     1255 ns/op
```

11× — and the gap widens with grid size (lock cost is per-cell, savings are per-batch).

## Testing

- `TestSafeEmulatorViewUpdate` — basic read/write through the accessors
- `TestSafeEmulatorViewConcurrent` — grid-walking Views against concurrent Write pressure, `-race` clean
- Benchmarks above included

Related: #879 (same SafeEmulator synchronization layer).