### PR TITLE
perf(vt): ring-buffer Scrollback eviction + cheap trailing-blank scan

### DIFF
--- a/vt/scrollback.go
+++ b/vt/scrollback.go
@@ -10,8 +10,17 @@ import (
 const DefaultScrollbackSize = 10000
 
 // Scrollback represents a scrollback buffer that stores lines scrolled off the screen.
+//
+// Storage is a ring once the buffer reaches maxLines: head indexes
+// the oldest line and pushes overwrite in place. The previous
+// implementation removed the oldest line with slices.Delete — an
+// O(maxLines) memmove on EVERY push once full, which profiled as the
+// dominant cost of bulk output in a real emulator (every newline at
+// the bottom of the screen pushes a line; at the default 10k cap
+// that was ~240KB moved per line of output).
 type Scrollback struct {
 	lines    []uv.Line
+	head     int // index of the oldest line; 0 until the ring is full
 	maxLines int
 }
 
@@ -38,6 +47,15 @@ func (s *Scrollback) Push(line uv.Line) {
 	lastNonEmpty := -1
 	for i := len(line) - 1; i >= 0; i-- {
 		c := &line[i]
+		// Fast path: a structurally-blank cell (zero value or plain
+		// space, no style/link) via single whole-struct compares —
+		// one type-generated equality call per cell instead of
+		// Cell.Equal's interface-unwrapping color comparisons. This
+		// scan runs for every line pushed, which is every line of
+		// output once the screen is full.
+		if *c == uv.EmptyCell || *c == (uv.Cell{}) {
+			continue
+		}
 		if !c.IsZero() && !c.Equal(&uv.EmptyCell) {
 			lastNonEmpty = i
 			break
@@ -48,8 +66,10 @@ func (s *Scrollback) Push(line uv.Line) {
 	cloned := slices.Clone(line[:lastNonEmpty+1])
 
 	if len(s.lines) >= s.maxLines {
-		// Remove oldest line and append new one
-		s.lines = slices.Delete(s.lines, 0, 1)
+		// Ring is full: overwrite the oldest line in place.
+		s.lines[s.head] = cloned
+		s.head = (s.head + 1) % len(s.lines)
+		return
 	}
 	s.lines = append(s.lines, cloned)
 }
@@ -92,8 +112,10 @@ func (s *Scrollback) SetMaxLines(maxLines int) {
 
 	s.maxLines = maxLines
 	if len(s.lines) > maxLines {
-		// Remove oldest lines
-		s.lines = s.lines[len(s.lines)-maxLines:]
+		// Keep the newest maxLines lines, linearized.
+		all := s.Lines()
+		s.lines = all[len(all)-maxLines:]
+		s.head = 0
 	}
 }
 
@@ -104,16 +126,24 @@ func (s *Scrollback) Line(index int) uv.Line {
 	if s == nil || index < 0 || index >= len(s.lines) {
 		return nil
 	}
-	return s.lines[index]
+	return s.lines[(s.head+index)%len(s.lines)]
 }
 
 // Lines returns all lines in the scrollback buffer.
-// Index 0 is the oldest line.
+// Index 0 is the oldest line. When the ring has wrapped, this
+// allocates to return the lines in order; Line(i) is the
+// allocation-free accessor.
 func (s *Scrollback) Lines() []uv.Line {
 	if s == nil {
 		return nil
 	}
-	return s.lines
+	if s.head == 0 {
+		return s.lines
+	}
+	out := make([]uv.Line, len(s.lines))
+	n := copy(out, s.lines[s.head:])
+	copy(out[n:], s.lines[:s.head])
+	return out
 }
 
 // Clear removes all lines from the scrollback buffer.
@@ -122,6 +152,7 @@ func (s *Scrollback) Clear() {
 		return
 	}
 	s.lines = s.lines[:0]
+	s.head = 0
 }
 
 // CellAt returns the cell at the given position in the scrollback buffer.


### PR DESCRIPTION
## Problem

`Scrollback.Push` runs for **every line of output** once the screen is full, and it had two per-line costs that dominate bulk-output profiles:

1. **Eviction via `slices.Delete(s.lines, 0, 1)`** — once at capacity, every push memmoves the entire backing array. At the default 10,000-line cap that's ~240KB moved *per line of output*. Profiled at **~47% of total process CPU** in a real emulator ([xerotty](https://github.com/LXXero/xerotty)) flooding `seq 1 2000000` (perf, Linux).
2. **The trailing-blank trim scans with `Cell.Equal`**, whose `Style` comparison unwraps three `color.Color` interfaces per cell — paid for every trailing blank of every pushed line.

## Change

- Storage becomes a **ring** once full: `head` indexes the oldest line, pushes overwrite in place — O(1) eviction. Public API unchanged: `Line(i)` stays allocation-free (one mod); `Lines()` linearizes (allocating) only when the ring has wrapped, documented.
- The blank scan fast-paths structurally-blank cells (zero value or plain space) with whole-struct compares — one type-generated equality per cell; styled cells still fall through to the full `Equal` check.

## Results

Combined with the companion line-rotation PR in ultraviolet (charmbracelet/ultraviolet#119): `seq 1 2000000` into an 80×24 emulator went **31s → ~6–8s** wall in xerotty (this PR's share: 13.5s → ~8s).

Existing vt tests pass. Related: #887 (same per-frame-cost theme, different layer).