### PR TITLE
feat(vt): xterm-style scrollback-aware resize (Scrollback.Pop)

### DIFF
--- a/vt/emulator.go
+++ b/vt/emulator.go
@@ -215,6 +215,16 @@ func (e *Emulator) CursorPosition() uv.Position {
 
 // Resize resizes the terminal.
 func (e *Emulator) Resize(width int, height int) {
+	// Primary screen resizes the xterm way: grow pulls history back down
+	// so content stays bottom-anchored, shrink pushes the displaced top
+	// rows into scrollback. resizeReflow moves scrs[0]'s own cursor row
+	// to follow the content, so the cursor is read back AFTER the resize.
+	// The alt screen has no scrollback and is owned by a full-screen app
+	// that repaints on SIGWINCH, so it keeps the plain pad/cut.
+	e.scrs[0].resizeReflow(width, height)
+	e.scrs[1].Resize(width, height)
+	e.tabstops = uv.DefaultTabStops(width)
+
 	x, y := e.scr.CursorPosition()
 	if e.atPhantom {
 		if x < width-1 {
@@ -235,10 +245,6 @@ func (e *Emulator) Resize(width int, height int) {
 	if x >= width {
 		x = width - 1
 	}
-
-	e.scrs[0].Resize(width, height)
-	e.scrs[1].Resize(width, height)
-	e.tabstops = uv.DefaultTabStops(width)
 
 	e.setCursor(x, y)
 

--- a/vt/resize_reflow_test.go
+++ b/vt/resize_reflow_test.go
@@ -1,0 +1,110 @@
+package vt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+func reflowRowText(e *Emulator, y int) string {
+	var b strings.Builder
+	for x := 0; x < e.Width(); x++ {
+		if c := e.CellAt(x, y); c != nil && c.Content != "" {
+			b.WriteString(c.Content)
+		} else {
+			b.WriteByte(' ')
+		}
+	}
+	return strings.TrimRight(b.String(), " ")
+}
+
+// Growing taller must pull lines back down from scrollback so existing
+// content stays anchored to the BOTTOM (xterm behavior), instead of
+// padding blanks at the bottom and leaving the old frame at the top —
+// the duplicated-text-on-stretch bug for bottom-anchored TUIs.
+func TestResizeGrowPullsScrollbackBottomAnchored(t *testing.T) {
+	e := NewEmulator(20, 4)
+	for i := 1; i <= 8; i++ {
+		e.WriteString(fmt.Sprintf("L%d\r\n", i))
+	}
+	beforeSB := e.ScrollbackLen()
+	if beforeSB < 3 {
+		t.Fatalf("need >=3 scrollback lines for the test, got %d", beforeSB)
+	}
+	var before []string
+	for y := 0; y < 4; y++ {
+		before = append(before, reflowRowText(e, y))
+	}
+	curBefore := e.CursorPosition().Y
+
+	e.Resize(20, 7) // grow by 3
+
+	// Old visible content stayed anchored to the bottom (rows 3..6).
+	for y := 0; y < 4; y++ {
+		if got := reflowRowText(e, y+3); got != before[y] {
+			t.Errorf("bottom row %d = %q, want %q (content not bottom-anchored)", y+3, got, before[y])
+		}
+	}
+	// Scrollback shrank by the 3 pulled lines.
+	if got := e.ScrollbackLen(); got != beforeSB-3 {
+		t.Errorf("scrollback len = %d, want %d", got, beforeSB-3)
+	}
+	// The revealed top row is real pulled history, not blank.
+	if reflowRowText(e, 0) == "" {
+		t.Error("top row empty after grow; expected pulled scrollback content")
+	}
+	// Cursor moved down with the content.
+	if got := e.CursorPosition().Y; got != curBefore+3 {
+		t.Errorf("cursor Y = %d, want %d (should follow content down)", got, curBefore+3)
+	}
+}
+
+// Shrinking pushes the displaced TOP lines into scrollback (recoverable)
+// and keeps the bottom rows + cursor.
+func TestResizeShrinkPushesToScrollback(t *testing.T) {
+	e := NewEmulator(20, 6)
+	for i := 1; i <= 6; i++ {
+		e.WriteString(fmt.Sprintf("R%d", i))
+		if i < 6 {
+			e.WriteString("\r\n")
+		}
+	}
+	// Cursor is on the last written row near the bottom.
+	beforeSB := e.ScrollbackLen()
+	bottom := reflowRowText(e, e.Height()-1)
+
+	e.Resize(20, 3) // shrink by 3
+
+	if got := e.ScrollbackLen(); got <= beforeSB {
+		t.Errorf("scrollback len = %d, want > %d (top lines pushed)", got, beforeSB)
+	}
+	// The bottom row survived the shrink.
+	if got := reflowRowText(e, e.Height()-1); got != bottom {
+		t.Errorf("bottom row after shrink = %q, want %q", got, bottom)
+	}
+}
+
+// Pop is the inverse of Push for the newest line, across the wrapped ring.
+func TestScrollbackPop(t *testing.T) {
+	sb := NewScrollback(3) // small so it wraps
+	mk := func(s string) uv.Line { return uv.Line{{Content: s, Width: 1}} }
+	for _, s := range []string{"a", "b", "c", "d", "e"} { // wraps: keeps c,d,e
+		sb.Push(mk(s))
+	}
+	if sb.Len() != 3 {
+		t.Fatalf("len = %d, want 3", sb.Len())
+	}
+	got := []string{}
+	for sb.Len() > 0 {
+		got = append(got, sb.Pop()[0].Content)
+	}
+	want := []string{"e", "d", "c"} // newest-first
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("pop order = %v, want %v", got, want)
+	}
+	if sb.Pop() != nil {
+		t.Error("Pop on empty should be nil")
+	}
+}

--- a/vt/screen.go
+++ b/vt/screen.go
@@ -81,6 +81,99 @@ func (s *Screen) Resize(width int, height int) {
 	s.scroll = s.buf.Bounds()
 }
 
+// resizeReflow resizes a scrollback-backed (primary) screen the way
+// xterm/vte do, rather than the dumb pad-bottom / cut-bottom of Resize:
+//
+//   - Growing taller pulls up to delta lines back DOWN from scrollback
+//     onto the TOP, so existing content (and the cursor) stays anchored
+//     to the bottom. Without this, a repaint-in-place TUI that anchors
+//     its UI to the bottom (a shell prompt, Claude Code) repaints over
+//     the newly-added bottom space while its old frame lingers at the
+//     top — a duplicated ghost until the app is forced to fully redraw.
+//   - Shrinking pushes the displaced TOP lines into scrollback (they're
+//     recoverable by scrolling up) and keeps the bottom rows + cursor.
+//
+// Width changes still use the plain per-line pad/cut — vt/uv don't
+// rewrap. The cursor row (s.cur.Y) is moved to follow the content so
+// the active screen's cursor stays correct. Returns nothing; callers
+// read the adjusted cursor back from the screen.
+func (s *Screen) resizeReflow(width, height int) {
+	if s.buf == nil {
+		s.buf = uv.NewRenderBuffer(width, height)
+		s.scroll = s.buf.Bounds()
+		return
+	}
+	oldH := s.buf.Height()
+
+	// Width first: plain pad/cut per line (no rewrap), keeping height.
+	if width != s.buf.Width() {
+		s.buf.Resize(width, oldH)
+	}
+
+	switch {
+	case height > oldH:
+		// GROW: pull min(delta, scrollbackLen) lines onto the top.
+		delta := height - oldH
+		pull := min(delta, s.scrollback.Len())
+		newLines := make([]uv.Line, 0, height)
+		// Pop returns newest-first; place oldest-at-top so the pulled
+		// block reads in history order just above the old content.
+		pulled := make([]uv.Line, pull)
+		for i := pull - 1; i >= 0; i-- {
+			pulled[i] = fitLine(s.scrollback.Pop(), width)
+		}
+		newLines = append(newLines, pulled...)
+		newLines = append(newLines, s.buf.Lines...)
+		for i := 0; i < delta-pull; i++ {
+			newLines = append(newLines, blankLine(width))
+		}
+		s.buf.Lines = newLines
+		s.cur.Y += pull
+
+	case height < oldH:
+		// SHRINK: push the top lines above the cursor into scrollback so
+		// the cursor stays visible; cut any remainder from the bottom.
+		drop := oldH - height
+		top := min(drop, s.cur.Y)
+		for i := 0; i < top; i++ {
+			s.scrollback.Push(s.buf.Lines[i])
+		}
+		kept := make([]uv.Line, height)
+		copy(kept, s.buf.Lines[top:top+height])
+		s.buf.Lines = kept
+		s.cur.Y -= top
+		if s.cur.Y < 0 {
+			s.cur.Y = 0
+		}
+	}
+	s.buf.Touched = nil
+	s.scroll = s.buf.Bounds()
+}
+
+// blankLine returns a fresh line of width empty cells.
+func blankLine(width int) uv.Line {
+	l := make(uv.Line, width)
+	for i := range l {
+		l[i] = uv.EmptyCell
+	}
+	return l
+}
+
+// fitLine returns a copy of line padded or truncated to exactly width
+// cells (scrollback lines are stored trailing-trimmed, so they're
+// usually shorter than the screen).
+func fitLine(line uv.Line, width int) uv.Line {
+	l := make(uv.Line, width)
+	for i := range l {
+		if i < len(line) {
+			l[i] = line[i]
+		} else {
+			l[i] = uv.EmptyCell
+		}
+	}
+	return l
+}
+
 // Width returns the width of the screen.
 func (s *Screen) Width() int {
 	return s.buf.Width()

--- a/vt/scrollback.go
+++ b/vt/scrollback.go
@@ -10,8 +10,17 @@ import (
 const DefaultScrollbackSize = 10000
 
 // Scrollback represents a scrollback buffer that stores lines scrolled off the screen.
+//
+// Storage is a ring once the buffer reaches maxLines: head indexes
+// the oldest line and pushes overwrite in place. The previous
+// implementation removed the oldest line with slices.Delete — an
+// O(maxLines) memmove on EVERY push once full, which profiled as the
+// dominant cost of bulk output in a real emulator (every newline at
+// the bottom of the screen pushes a line; at the default 10k cap
+// that was ~240KB moved per line of output).
 type Scrollback struct {
 	lines    []uv.Line
+	head     int // index of the oldest line; 0 until the ring is full
 	maxLines int
 }
 
@@ -38,6 +47,15 @@ func (s *Scrollback) Push(line uv.Line) {
 	lastNonEmpty := -1
 	for i := len(line) - 1; i >= 0; i-- {
 		c := &line[i]
+		// Fast path: a structurally-blank cell (zero value or plain
+		// space, no style/link) via single whole-struct compares —
+		// one type-generated equality call per cell instead of
+		// Cell.Equal's interface-unwrapping color comparisons. This
+		// scan runs for every line pushed, which is every line of
+		// output once the screen is full.
+		if *c == uv.EmptyCell || *c == (uv.Cell{}) {
+			continue
+		}
 		if !c.IsZero() && !c.Equal(&uv.EmptyCell) {
 			lastNonEmpty = i
 			break
@@ -48,8 +66,10 @@ func (s *Scrollback) Push(line uv.Line) {
 	cloned := slices.Clone(line[:lastNonEmpty+1])
 
 	if len(s.lines) >= s.maxLines {
-		// Remove oldest line and append new one
-		s.lines = slices.Delete(s.lines, 0, 1)
+		// Ring is full: overwrite the oldest line in place.
+		s.lines[s.head] = cloned
+		s.head = (s.head + 1) % len(s.lines)
+		return
 	}
 	s.lines = append(s.lines, cloned)
 }
@@ -92,8 +112,10 @@ func (s *Scrollback) SetMaxLines(maxLines int) {
 
 	s.maxLines = maxLines
 	if len(s.lines) > maxLines {
-		// Remove oldest lines
-		s.lines = s.lines[len(s.lines)-maxLines:]
+		// Keep the newest maxLines lines, linearized.
+		all := s.Lines()
+		s.lines = all[len(all)-maxLines:]
+		s.head = 0
 	}
 }
 
@@ -104,16 +126,24 @@ func (s *Scrollback) Line(index int) uv.Line {
 	if s == nil || index < 0 || index >= len(s.lines) {
 		return nil
 	}
-	return s.lines[index]
+	return s.lines[(s.head+index)%len(s.lines)]
 }
 
 // Lines returns all lines in the scrollback buffer.
-// Index 0 is the oldest line.
+// Index 0 is the oldest line. When the ring has wrapped, this
+// allocates to return the lines in order; Line(i) is the
+// allocation-free accessor.
 func (s *Scrollback) Lines() []uv.Line {
 	if s == nil {
 		return nil
 	}
-	return s.lines
+	if s.head == 0 {
+		return s.lines
+	}
+	out := make([]uv.Line, len(s.lines))
+	n := copy(out, s.lines[s.head:])
+	copy(out[n:], s.lines[:s.head])
+	return out
 }
 
 // Clear removes all lines from the scrollback buffer.
@@ -122,6 +152,7 @@ func (s *Scrollback) Clear() {
 		return
 	}
 	s.lines = s.lines[:0]
+	s.head = 0
 }
 
 // CellAt returns the cell at the given position in the scrollback buffer.

--- a/vt/scrollback.go
+++ b/vt/scrollback.go
@@ -87,6 +87,34 @@ func (s *Scrollback) PushN(buf *uv.RenderBuffer, y, n int) {
 	}
 }
 
+// Pop removes and returns the most-recently-pushed (newest) line, or
+// nil if the buffer is empty. It's the inverse of Push: a grow-taller
+// resize uses it to pull history back down onto the screen so existing
+// content stays anchored to the bottom (see Screen.resizeReflow). This
+// is a cold path (resize only), so when the ring has wrapped it
+// linearizes the remaining lines rather than tracking a tail index.
+func (s *Scrollback) Pop() uv.Line {
+	if s == nil || len(s.lines) == 0 {
+		return nil
+	}
+	n := len(s.lines)
+	idx := (s.head + n - 1) % n // ring position of the newest line
+	line := s.lines[idx]
+	if s.head == 0 {
+		// Not wrapped: the newest line is the last slice element.
+		s.lines = s.lines[:n-1]
+	} else {
+		// Wrapped ring: drop the newest and re-linearize so head == 0.
+		out := make([]uv.Line, 0, n-1)
+		for i := 0; i < n-1; i++ {
+			out = append(out, s.lines[(s.head+i)%n])
+		}
+		s.lines = out
+		s.head = 0
+	}
+	return line
+}
+
 // Len returns the number of lines in the scrollback buffer.
 func (s *Scrollback) Len() int {
 	if s == nil {


### PR DESCRIPTION
## Problem

`Emulator.Resize` pads/cuts the primary screen at the **bottom** and keeps content **top-anchored**. A repaint-in-place TUI that anchors its UI to the bottom (a shell prompt, Claude Code, anything using cursor-positioned redraws on the primary screen) then repaints over the newly-added bottom space while its **old frame lingers at the top** — a duplicated ghost on every grow until the app is forced to fully redraw. Growing taller also fails to *reveal* scrollback history, which is what users expect when they enlarge a window.

## Change

Make the primary screen resize the way xterm/vte do:

- **Grow taller** pulls up to `delta` lines back **down from scrollback** onto the top, so existing content (and the cursor) stays anchored to the bottom.
- **Shrink** pushes the displaced **top** lines into scrollback (recoverable by scrolling up) and keeps the bottom rows + cursor.

Width changes keep the plain per-line pad/cut (vt/uv never rewrap). The **alt screen** — no scrollback, owned by a full-screen app that repaints on `SIGWINCH` — keeps the plain `Resize`.

## API

Adds `Scrollback.Pop()` — the inverse of `Push` for the newest line (linearizes the wrapped ring on this cold, resize-only path) — and an internal `Screen.resizeReflow`, wired into `Emulator.Resize` for the primary screen.

## Tests

- grow pulls scrollback, content stays bottom-anchored, cursor follows;
- shrink pushes top lines into scrollback, bottom row + cursor preserved;
- `Pop` ordering across a wrapped ring.

Full `vt` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)