### PR TITLE
fix(ansi): reset parser state after grapheme cluster in Truncate

### DIFF
--- a/ansi/truncate.go
+++ b/ansi/truncate.go
@@ -97,6 +97,12 @@ func truncate(m Method, s string, length int, tail string) string {
 			i += len(cluster)
 			curWidth += width
 
+			// A grapheme cluster always leaves us back in the ground state,
+			// even when we skip it below. Reset it here so a following byte
+			// isn't mistaken for the continuation of a preceding escape
+			// sequence that this cluster interrupted.
+			pstate = parser.GroundState
+
 			// Are we ignoring? Skip to the next byte
 			if ignoring {
 				continue
@@ -115,8 +121,6 @@ func truncate(m Method, s string, length int, tail string) string {
 
 			buf.WriteString(cluster)
 
-			// Done collecting, now we're back in the ground state.
-			pstate = parser.GroundState
 			continue
 		}
 

--- a/ansi/truncate_test.go
+++ b/ansi/truncate_test.go
@@ -355,6 +355,33 @@ func TestTruncateLeft(t *testing.T) {
 	}
 }
 
+// When a grapheme cluster interrupts an unterminated escape sequence, the
+// parser state was left mid-sequence, so the next byte was mistaken for the
+// sequence's final byte and emitted past the truncation point, making the
+// result wider than the requested length. See charmbracelet/x#541.
+func TestTruncateObeysWidth(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		width  int
+		expect string
+	}{
+		{"escape interrupted by grapheme", "\x1b[3‘s", 1, "\x1b[3…"},
+		{"text before interrupted escape", "abcd\x1b[3‘sefg", 5, "abcd\x1b[3…"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := Truncate(c.input, c.width, "…")
+			if result != c.expect {
+				t.Errorf("expected: %q\n     got: %q", c.expect, result)
+			}
+			if w := StringWidth(result); w > c.width {
+				t.Errorf("width %d exceeds requested %d for %q", w, c.width, result)
+			}
+		})
+	}
+}
+
 func BenchmarkTruncateLeft(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		b.ReportAllocs()


### PR DESCRIPTION
Fixes the `Truncate` part of #541.

`Truncate` could return a string wider than the requested length. In the `Utf8State` branch of `truncate()`, `pstate` was reset to `GroundState` only on the path that writes the cluster; the "ignoring" and "too wide" `continue` paths left it mid-sequence. When a grapheme cluster interrupts an unterminated escape (e.g. `\x1b[3` followed by `‘`), `pstate` stayed in CSI state, so the next byte was treated as the sequence's final byte and written through the `default` branch past the truncation point.

A grapheme cluster always returns the parser to the ground state, so this moves the reset to cover all three exit paths.

Before the fix:

```
Truncate("\x1b[3‘s", 1, "…")          // "\x1b[3…s", width 2
Truncate("7\"(z\x1b[3‘saB'um", 5, "…") // width 6
```

The fuzz target in the issue failed almost immediately before; with this change `StringWidth(Truncate(s, n, tail)) <= n` holds across a long fuzz run. Added `TestTruncateObeysWidth` for the case.

This only touches `Truncate` (and `TruncateWc`, which shares `truncate()`). I left `TruncateLeft` alone: as noted in the thread it removes n columns from the left, so its result is intentionally `total-n` wide and the issue's fuzz assertion checks a different invariant for it.
