### PR TITLE
vt: clamp stale scroll margins to screen bounds

### DIFF
--- a/vt/margins_test.go
+++ b/vt/margins_test.go
@@ -1,0 +1,63 @@
+package vt
+
+import "testing"
+
+// These tests cover the scroll-margin bounds invariant: an explicit DECSTBM
+// bottom or DECSLRM right margin beyond the current screen size must be
+// clamped (matching xterm), and the stored scroll region must never exceed
+// the buffer bounds. A child TUI can legitimately emit margins computed from
+// a stale size while resizes race through the PTY.
+
+func TestDECSTBMClampsExplicitBottomToHeight(t *testing.T) {
+	em := NewEmulator(80, 63)
+
+	// Explicit bottom (64) beyond the screen height (63).
+	em.Write([]byte("\x1b[1;64r"))
+
+	if got := em.scr.scroll.Max.Y; got != 63 {
+		t.Errorf("scroll.Max.Y = %d, want 63 (clamped to height)", got)
+	}
+}
+
+func TestDECSTBMKeepsValidExplicitBottom(t *testing.T) {
+	em := NewEmulator(80, 24)
+
+	em.Write([]byte("\x1b[2;20r"))
+
+	if got := em.scr.scroll.Min.Y; got != 1 {
+		t.Errorf("scroll.Min.Y = %d, want 1", got)
+	}
+	if got := em.scr.scroll.Max.Y; got != 20 {
+		t.Errorf("scroll.Max.Y = %d, want 20", got)
+	}
+}
+
+func TestDECSLRMClampsExplicitRightToWidth(t *testing.T) {
+	em := NewEmulator(80, 24)
+
+	// DECSLRM requires mode 69 (DECLRMM); explicit right (100) beyond the
+	// screen width (80).
+	em.Write([]byte("\x1b[?69h\x1b[1;100s"))
+
+	if got := em.scr.scroll.Max.X; got != 80 {
+		t.Errorf("scroll.Max.X = %d, want 80 (clamped to width)", got)
+	}
+}
+
+// TestReverseIndexAfterStaleMarginsDoesNotPanic reproduces the production
+// crash path: a DECSTBM computed against a taller screen, followed by a
+// reverse index at the top of the scroll region, used to leave an
+// out-of-bounds scroll region and panic inside InsertLine.
+func TestReverseIndexAfterStaleMarginsDoesNotPanic(t *testing.T) {
+	em := NewEmulator(80, 64)
+	em.Write([]byte("\x1b[1;64r")) // valid at 80x64
+
+	em.Resize(80, 63) // browser re-fit shrinks the screen
+
+	// Child still believes the screen is 64 rows tall.
+	em.Write([]byte("\x1b[1;64r\x1b[1;1H\x1bM\x1bM\x1bM"))
+
+	if got, want := em.scr.scroll.Max.Y, 63; got != want {
+		t.Errorf("scroll.Max.Y = %d, want %d", got, want)
+	}
+}

--- a/vt/screen.go
+++ b/vt/screen.go
@@ -134,14 +134,31 @@ func (s *Screen) FillArea(c *uv.Cell, area uv.Rectangle) {
 	s.touchArea(area)
 }
 
-// setHorizontalMargins sets the horizontal margins.
+// setHorizontalMargins sets the horizontal margins. The margins are clamped
+// to the buffer bounds so the scroll region can never address cells outside
+// the buffer: a terminal application may compute margins from a stale size
+// while a resize races through the PTY, and an out-of-bounds scroll region
+// later corrupts scroll operations. A region that degenerates after
+// clamping is ignored, matching how DECSLRM treats left >= right.
 func (s *Screen) setHorizontalMargins(left, right int) {
+	left = max(0, left)
+	right = min(right, s.buf.Width())
+	if left >= right {
+		return
+	}
 	s.scroll.Min.X = left
 	s.scroll.Max.X = right
 }
 
-// setVerticalMargins sets the vertical margins.
+// setVerticalMargins sets the vertical margins. The margins are clamped to
+// the buffer bounds; see setHorizontalMargins. A region that degenerates
+// after clamping is ignored, matching how DECSTBM treats top >= bottom.
 func (s *Screen) setVerticalMargins(top, bottom int) {
+	top = max(0, top)
+	bottom = min(bottom, s.buf.Height())
+	if top >= bottom {
+		return
+	}
 	s.scroll.Min.Y = top
 	s.scroll.Max.Y = bottom
 }
@@ -405,7 +422,7 @@ func (s *Screen) SetScrollback(sb *Scrollback) {
 // SetScrollbackSize sets the maximum number of lines in the scrollback buffer.
 func (s *Screen) SetScrollbackSize(maxLines int) {
 	if s.scrollback == nil {
-		s.scrollback = NewScrollback(maxLines)
+		scrollback = NewScrollback(maxLines)
 	} else {
 		s.scrollback.SetMaxLines(maxLines)
 	}

--- a/vt/screen.go
+++ b/vt/screen.go
@@ -422,7 +422,7 @@ func (s *Screen) SetScrollback(sb *Scrollback) {
 // SetScrollbackSize sets the maximum number of lines in the scrollback buffer.
 func (s *Screen) SetScrollbackSize(maxLines int) {
 	if s.scrollback == nil {
-		scrollback = NewScrollback(maxLines)
+		s.scrollback = NewScrollback(maxLines)
 	} else {
 		s.scrollback.SetMaxLines(maxLines)
 	}


### PR DESCRIPTION
## Summary
Clamp horizontal and vertical scroll margins to the current screen bounds when they are stored on `Screen`.

## Why
A terminal app can emit `DECSTBM` or `DECSLRM` using a stale size while a resize is racing through the PTY. Without clamping, `Screen.scroll` can retain an out-of-bounds bottom/right edge, and a later reverse-index / scroll operation can drive `InsertLineArea` past the buffer bounds.

## Changes
- clamp `setHorizontalMargins` to `[0,width]`
- clamp `setVerticalMargins` to `[0,height]`
- ignore degenerate regions after clamping, matching existing `left >= right` / `top >= bottom` behavior
- add regression tests for stale `DECSTBM`, stale `DECSLRM`, and the reverse-index crash path

## Test
- `go test ./...` in `vt/`
