### PR TITLE
fix(ansi/kitty): serialize negative z-index

### DIFF
--- a/ansi/kitty/options.go
+++ b/ansi/kitty/options.go
@@ -248,7 +248,7 @@ func (o *Options) Options() (opts []string) {
 		opts = append(opts, fmt.Sprintf("y=%d", o.Y))
 	}
 
-	if o.Z > 0 {
+	if o.Z != 0 {
 		opts = append(opts, fmt.Sprintf("z=%d", o.Z))
 	}
 

--- a/ansi/kitty/options_test.go
+++ b/ansi/kitty/options_test.go
@@ -1,9 +1,11 @@
 package kitty
 
 import (
+	"math"
 	"reflect"
 	"slices"
 	"sort"
+	"strconv"
 	"testing"
 )
 
@@ -133,6 +135,21 @@ func TestOptions_Options(t *testing.T) {
 				Delete: 0,
 			},
 			expected: []string{}, // Should use defaults and not generate options
+		},
+		{
+			name:     "positive z-index",
+			options:  Options{Z: 1},
+			expected: []string{"z=1"},
+		},
+		{
+			name:     "negative z-index",
+			options:  Options{Z: -1},
+			expected: []string{"z=-1"},
+		},
+		{
+			name:     "very negative z-index",
+			options:  Options{Z: math.MinInt32},
+			expected: []string{"z=" + strconv.Itoa(math.MinInt32)},
 		},
 	}
 


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

This fixes #926, i.e. kitty.Options now doesn't ignore negative z-indexes.