### PR TITLE
fix(xpty): report context cancellation in WaitProcess

### DIFF
--- a/xpty/xpty.go
+++ b/xpty/xpty.go
@@ -76,6 +76,11 @@ func NewPty(width, height int, opts ...PtyOption) (Pty, error) {
 // WaitProcess waits for the process to exit.
 // This exists because on Windows, cmd.Wait() doesn't work with ConPty.
 // When the OS is not windows, it'll simply fall back to cmd.Wait().
+//
+// If ctx is canceled, the process is killed, WaitProcess waits for it to be
+// reaped, and the returned error reports the cancellation: ctx.Err() on a
+// successful kill, or an error joining ctx.Err() and the kill error if the
+// kill itself failed.
 func WaitProcess(ctx context.Context, cmd *exec.Cmd) (err error) {
 	if runtime.GOOS != "windows" {
 		return cmd.Wait() //nolint:wrapcheck
@@ -98,10 +103,25 @@ func WaitProcess(ctx context.Context, cmd *exec.Cmd) (err error) {
 
 	select {
 	case <-ctx.Done():
-		err = cmd.Process.Kill()
+		killErr := cmd.Process.Kill()
+		// Reap the process so it doesn't linger as a zombie.
+		r := <-donec
+		cmd.ProcessState = r.ProcessState
+		if killErr != nil {
+			return errors.Join(ctx.Err(), killErr)
+		}
+		return ctx.Err() //nolint:wrapcheck // sentinel; callers use errors.Is
 	case r := <-donec:
 		cmd.ProcessState = r.ProcessState
 		err = r.error
+	}
+
+	// On Windows, os.Process.Wait returns nil even when the process exits
+	// with a non-zero code; the *exec.ExitError that exec.Cmd.Wait would
+	// return never materializes. Synthesize it so callers get the same
+	// error shape as exec.Cmd.Wait on any platform.
+	if err == nil && cmd.ProcessState != nil && !cmd.ProcessState.Success() {
+		err = &exec.ExitError{ProcessState: cmd.ProcessState}
 	}
 
 	return err

--- a/xpty/xpty_other_test.go
+++ b/xpty/xpty_other_test.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package xpty
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWaitProcessCancelIgnored(t *testing.T) {
+	// The unix path ignores ctx: it waits for the process to exit on its
+	// own. Cancellation there is exec.CommandContext's job.
+	cmd := helperCmd("GO_HELPER_SLEEP_SHORT=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	if err := WaitProcess(ctx, cmd); err != nil {
+		t.Fatalf("expected nil error on unix, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 900*time.Millisecond {
+		t.Fatalf("returned after %v; unix path should wait for natural exit", elapsed)
+	}
+}

--- a/xpty/xpty_test.go
+++ b/xpty/xpty_test.go
@@ -1,0 +1,70 @@
+package xpty
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// helperCmd re-execs the test binary as a helper subprocess, so tests
+// don't depend on any external command. GO_HELPER_SLEEP makes the helper
+// block until killed; GO_HELPER_EXIT sets its exit code.
+func helperCmd(env ...string) *exec.Cmd {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHelperProcess$")
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	cmd.Env = append(cmd.Env, env...)
+	return cmd
+}
+
+func TestWaitProcessSuccess(t *testing.T) {
+	cmd := helperCmd()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := WaitProcess(context.Background(), cmd); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if cmd.ProcessState == nil {
+		t.Fatal("expected ProcessState to be set")
+	}
+}
+
+func TestWaitProcessNonZeroExit(t *testing.T) {
+	cmd := helperCmd("GO_HELPER_EXIT=3")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	err := WaitProcess(context.Background(), cmd)
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *exec.ExitError, got %T: %v", err, err)
+	}
+	if exitErr.ExitCode() != 3 {
+		t.Fatalf("expected exit code 3, got %d", exitErr.ExitCode())
+	}
+}
+
+// TestHelperProcess is not a real test; it runs when the test binary is
+// re-executed as a helper subprocess.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	if os.Getenv("GO_HELPER_SLEEP") == "1" {
+		time.Sleep(time.Minute)
+	}
+	if os.Getenv("GO_HELPER_SLEEP_SHORT") == "1" {
+		time.Sleep(time.Second)
+	}
+	if code := os.Getenv("GO_HELPER_EXIT"); code != "" {
+		var n int
+		if _, err := fmt.Sscan(code, &n); err == nil {
+			os.Exit(n)
+		}
+	}
+	os.Exit(0)
+}

--- a/xpty/xpty_windows_test.go
+++ b/xpty/xpty_windows_test.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package xpty
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestWaitProcessCancel(t *testing.T) {
+	cmd := helperCmd("GO_HELPER_SLEEP=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	err := WaitProcess(ctx, cmd)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if cmd.ProcessState == nil || !cmd.ProcessState.Exited() {
+		t.Fatal("expected process to be reaped after cancellation")
+	}
+}


### PR DESCRIPTION
On cancellation, WaitProcess killed the process but returned Kill()'s error, which is nil on success. A killed process therefore looked like a clean exit, and callers had no way to observe the cancellation. It also returned without waiting for the kill to be reaped, risking a zombie.

Now WaitProcess waits for the process to be reaped and returns ctx.Err() on a successful kill, or an error joining ctx.Err() and the kill error if the kill itself failed.

This aligns the windows path with the unix behavior callers already handle: on unix, context cancellation has always surfaced as an error via exec.CommandContext. The only observable change is on windows, where cancellation previously returned nil.