### PR TITLE
vt: make Emulator.closed atomic to fix the Close/Read data race

### DIFF
--- a/vt/emulator.go
+++ b/vt/emulator.go
@@ -3,6 +3,7 @@ package vt
 import (
 	"image/color"
 	"io"
+	"sync/atomic"
 
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/ultraviolet/screen"
@@ -67,8 +68,9 @@ type Emulator struct {
 	gl, gr  int
 	gsingle int // temporarily select GL or GR
 
-	// Indicates if the terminal is closed.
-	closed bool
+	// Indicates if the terminal is closed. Atomic because Close is the only
+	// way to unblock a parked Read, so the two necessarily run concurrently.
+	closed atomic.Bool
 
 	// atPhantom indicates if the cursor is out of bounds.
 	// When true, and a character is written, the cursor is moved to the next line.
@@ -249,7 +251,7 @@ func (e *Emulator) Resize(width int, height int) {
 
 // Read reads data from the terminal input buffer.
 func (e *Emulator) Read(p []byte) (n int, err error) {
-	if e.closed {
+	if e.closed.Load() {
 		return 0, io.EOF
 	}
 
@@ -258,17 +260,16 @@ func (e *Emulator) Read(p []byte) (n int, err error) {
 
 // Close closes the terminal.
 func (e *Emulator) Close() error {
-	if e.closed {
+	if !e.closed.CompareAndSwap(false, true) {
 		return nil
 	}
 
-	e.closed = true
 	return e.pw.CloseWithError(io.EOF) //nolint:wrapcheck
 }
 
 // Write writes data to the terminal output buffer.
 func (e *Emulator) Write(p []byte) (n int, err error) {
-	if e.closed {
+	if e.closed.Load() {
 		return 0, io.ErrClosedPipe
 	}
 


### PR DESCRIPTION
Closes #930

`Emulator.closed` is a plain `bool` that `Close` writes and `Read` reads with no synchronization between them, so `-race` flags every shutdown of an `Emulator` whose output is being consumed. `Read` blocks on an empty pipe and `Close` is the only thing that unblocks it, so there is no usage pattern that avoids the pair running concurrently.

`SafeEmulator` does not cover it either: its `Read` takes no lock (deliberately, so a parked reader can't hold `mu` against every writer) and it does not override `Close`, so the embedded `*Emulator.Close` is promoted unchanged.

## The change

`closed` becomes an `atomic.Bool`. The guard is an early-out rather than the mechanism — the actual unblocking is `pw.CloseWithError(io.EOF)` on an `io.Pipe`, which is internally synchronized and idempotent — so no mutex is needed and `Read` stays lock-free.

`Close` uses `CompareAndSwap` rather than a `Load` then a `Store`, which also makes it single-winner: two concurrent `Close` calls previously could both pass the guard and both call `CloseWithError`. Harmless, since that call is idempotent, but the CAS form costs nothing and says what it means.

## Verification

- `go test -race ./...` in `vt/` passes.
- A reproducer that reliably fails on `main` passes with this change:

```go
func TestCloseRacesParkedRead(t *testing.T) {
	e := vt.NewEmulator(80, 24)

	done := make(chan struct{})
	go func() {
		defer close(done)
		buf := make([]byte, 64)
		for {
			if _, err := e.Read(buf); err != nil {
				return
			}
		}
	}()

	time.Sleep(100 * time.Millisecond) // let the reader park inside Read
	if err := e.Close(); err != nil {
		t.Fatalf("Close: %v", err)
	}
	<-done
}
```

On `main` this reports the race at `emulator.go:252` (Read) against `emulator.go:265` (Close). With this change it passes.

- Downstream check: a terminal-multiplexing consumer of `vt` that had to exclude every shutdown-touching test from its `-race` job runs its full suite green, with no exclusions, against a patched `vt`.

I did not add the reproducer as a test in this PR since it needs a sleep to set up the condition; happy to include it in whatever form suits the package if you'd like it covered.
