### PR TITLE
fix(wcwidth): measure wcwidth per codepoint

### DIFF
--- a/ansi/method_test.go
+++ b/ansi/method_test.go
@@ -19,8 +19,25 @@ func TestMethod_StringWidth(t *testing.T) {
 		{"wide chars grapheme width", GraphemeWidth, "コンニチハ", 10},
 		{"emoji wcwidth", WcWidth, "😀", 2},
 		{"emoji grapheme width", GraphemeWidth, "😀", 2},
-		{"flag emoji wcwidth", WcWidth, "🏳️‍🌈", 1},
+		// Wcwidth measures per codepoint, so a ZWJ sequence is as wide as the
+		// emoji it joins: a white flag, a zero-width VS16 and ZWJ, and a
+		// rainbow. Grapheme width measures the cluster as the one glyph a
+		// terminal in Unicode core mode draws.
+		{"flag emoji wcwidth", WcWidth, "🏳️‍🌈", 3},
 		{"flag emoji grapheme width", GraphemeWidth, "🏳️‍🌈", 2},
+		// Unicode 15.1 merged Indic conjuncts into single clusters, but a
+		// terminal without Unicode core mode still advances once per
+		// consonant.
+		{"devanagari wcwidth", WcWidth, "नमस्ते", 4},
+		{"devanagari grapheme width", GraphemeWidth, "नमस्ते", 3},
+		{"zwj family wcwidth", WcWidth, "👨‍👩‍👧‍👦", 8},
+		{"zwj family grapheme width", GraphemeWidth, "👨‍👩‍👧‍👦", 2},
+		{"skin tone wcwidth", WcWidth, "👍🏽", 4},
+		{"skin tone grapheme width", GraphemeWidth, "👍🏽", 2},
+		{"combining mark wcwidth", WcWidth, "é", 1},
+		{"combining mark grapheme width", GraphemeWidth, "é", 1},
+		{"vs16 wcwidth", WcWidth, "⚠️", 1},
+		{"vs16 grapheme width", GraphemeWidth, "⚠️", 2},
 	}
 	for _, tt := range tests {
 		if got := tt.m.StringWidth(tt.in); got != tt.want {

--- a/ansi/parser_decode.go
+++ b/ansi/parser_decode.go
@@ -437,13 +437,13 @@ func FirstGraphemeCluster[T string | []byte](b T, m Method) (T, int) {
 	case string:
 		cluster := graphemes.FromString(b).First()
 		if m == WcWidth {
-			return T(cluster), wcOptions.StringWidth(cluster)
+			return T(cluster), wcClusterWidth(cluster)
 		}
 		return T(cluster), dwOptions.String(cluster)
 	case []byte:
 		cluster := graphemes.FromBytes(b).First()
 		if m == WcWidth {
-			return T(cluster), wcOptions.StringWidth(string(cluster))
+			return T(cluster), wcClusterWidth(cluster)
 		}
 		return T(cluster), dwOptions.Bytes(cluster)
 	}

--- a/ansi/wcwidth.go
+++ b/ansi/wcwidth.go
@@ -1,0 +1,99 @@
+package ansi
+
+import (
+	"slices"
+	"unicode"
+	"unicode/utf8"
+)
+
+// zeroWidthTables are the categories whose runes don't advance the cursor:
+// nonspacing and enclosing marks, and format characters such as ZWJ and the
+// variation selectors.
+var zeroWidthTables = []*unicode.RangeTable{unicode.Mn, unicode.Me, unicode.Cf}
+
+// zeroWidthBMP is a bitset of the [zeroWidthTables] runes in the basic
+// multilingual plane. Measuring runs a lookup per rune, and a bit test is a
+// good deal cheaper than searching three range tables. Runes above the BMP are
+// rare enough in terminal output to leave on the slow path.
+var zeroWidthBMP [0x10000 / 64]uint64
+
+// zeroWidthHigh holds the [zeroWidthTables] runes above the BMP, expanded and
+// sorted so a lookup is one binary search.
+var zeroWidthHigh []rune
+
+func init() {
+	for _, t := range zeroWidthTables {
+		for _, r := range t.R16 {
+			for c := rune(r.Lo); c <= rune(r.Hi); c += rune(r.Stride) {
+				zeroWidthBMP[c>>6] |= 1 << (c & 63)
+			}
+		}
+		for _, r := range t.R32 {
+			for c := rune(r.Lo); c <= rune(r.Hi); c += rune(r.Stride) {
+				zeroWidthHigh = append(zeroWidthHigh, c)
+			}
+		}
+	}
+	slices.Sort(zeroWidthHigh)
+}
+
+// isZeroWidthHigh reports whether a rune above the BMP is zero width.
+func isZeroWidthHigh(r rune) bool {
+	_, ok := slices.BinarySearch(zeroWidthHigh, r)
+	return ok
+}
+
+// wcRuneWidth returns the number of columns a single rune advances the cursor,
+// i.e. wcwidth(3).
+//
+// Nonspacing and enclosing marks, along with format characters such as ZWJ and
+// the variation selectors, never advance the cursor. [runewidth] reports some
+// of them, most notably the Indic combining marks, as single width, so they're
+// classified here instead.
+func wcRuneWidth(r rune) int {
+	switch {
+	case r < 0x20, r >= 0x7f && r < 0xa0:
+		// C0 and C1 controls, and DEL, don't print.
+		return 0
+	case r < 0x7f:
+		// Printable ASCII. Everything above it can be East Asian Ambiguous,
+		// so it has to go through runewidth.
+		return 1
+	case r < 0x10000:
+		if zeroWidthBMP[r>>6]&(1<<(r&63)) != 0 {
+			return 0
+		}
+	case isZeroWidthHigh(r):
+		return 0
+	}
+	return wcOptions.RuneWidth(r)
+}
+
+// wcClusterWidth returns the number of columns a grapheme cluster occupies
+// under [WcWidth], which is the sum of the widths of its codepoints.
+//
+// Terminals that don't implement Unicode core mode (DEC mode 2027) advance the
+// cursor once per codepoint and know nothing about cluster boundaries. So a
+// cluster can be wider than the glyph it draws: Unicode 15.1 merged Indic
+// conjuncts into single clusters, and a terminal still puts "स्ते" in two
+// columns, one per consonant. ZWJ emoji sequences behave the same way, with
+// "👨‍👩‍👧‍👦" taking the eight columns of the four emoji it's built from.
+//
+// Measuring the cluster as a unit is [GraphemeWidth]'s job.
+func wcClusterWidth[T string | []byte](cluster T) int {
+	var width int
+	switch c := any(cluster).(type) {
+	case string:
+		for _, r := range c {
+			width += wcRuneWidth(r)
+		}
+	case []byte:
+		// Ranging over string(c) would copy the slice, so decode in place.
+		for len(c) > 0 {
+			r, size := utf8.DecodeRune(c)
+			width += wcRuneWidth(r)
+			c = c[size:]
+		}
+	}
+	return width
+}

--- a/ansi/wcwidth.go
+++ b/ansi/wcwidth.go
@@ -29,7 +29,8 @@ func init() {
 			}
 		}
 		for _, r := range t.R32 {
-			for c := rune(r.Lo); c <= rune(r.Hi); c += rune(r.Stride) {
+			// R32 range bounds are always valid runes.
+			for c := rune(r.Lo); c <= rune(r.Hi); c += rune(r.Stride) { //nolint:gosec
 				zeroWidthHigh = append(zeroWidthHigh, c)
 			}
 		}

--- a/ansi/wcwidth_test.go
+++ b/ansi/wcwidth_test.go
@@ -1,0 +1,135 @@
+package ansi
+
+import (
+	"testing"
+	"unicode"
+)
+
+// TestWcClusterWidth pins the rule that separates the two width models: under
+// wcwidth a grapheme cluster is worth the sum of its codepoints, however the
+// terminal ends up shaping it.
+func TestWcClusterWidth(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wc       int
+		grapheme int
+	}{
+		{"ascii", "a", 1, 1},
+		{"combining acute", "é", 1, 1},
+		{"devanagari conjunct", "स्ते", 2, 1},
+		{"devanagari kssa", "क्ष", 2, 1},
+		{"cjk", "世", 2, 2},
+		{"emoji", "🌈", 2, 2},
+		{"vs16", "⚠️", 1, 2},
+		{"vs15", "☹︎", 1, 1},
+		{"keycap", "1️⃣", 1, 2},
+		{"zwj pair", "👨‍💻", 4, 2},
+		{"zwj family", "👨‍👩‍👧‍👦", 8, 2},
+		{"zwj flag", "🏳️‍🌈", 3, 2},
+		{"skin tone", "👍🏽", 4, 2},
+		{"regional indicators", "🇺🇸", 2, 2},
+		{"halfwidth voiced mark", "ｶﾞ", 2, 1},
+		{"c1 string", "\u009bx", 1, 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := wcClusterWidth(tc.in); got != tc.wc {
+				t.Errorf("wcClusterWidth(%q) = %d, want %d", tc.in, got, tc.wc)
+			}
+			if got := wcClusterWidth([]byte(tc.in)); got != tc.wc {
+				t.Errorf("wcClusterWidth([]byte(%q)) = %d, want %d", tc.in, got, tc.wc)
+			}
+			if got := StringWidthWc(tc.in); got != tc.wc {
+				t.Errorf("StringWidthWc(%q) = %d, want %d", tc.in, got, tc.wc)
+			}
+			if got := StringWidth(tc.in); got != tc.grapheme {
+				t.Errorf("StringWidth(%q) = %d, want %d", tc.in, got, tc.grapheme)
+			}
+		})
+	}
+}
+
+// TestWcRuneWidth covers the classification the Unicode tables are consulted
+// for, since [runewidth] alone reports several of these as single width.
+func TestWcRuneWidth(t *testing.T) {
+	tests := []struct {
+		name string
+		r    rune
+		want int
+	}{
+		{"nul", 0, 0},
+		{"bell", 0x07, 0},
+		{"del", 0x7f, 0},
+		{"c1 pad", 0x80, 0},
+		{"c1 csi", 0x9b, 0},
+		{"c1 apc", 0x9f, 0},
+		{"ascii", 'a', 1},
+		{"latin1", 'é', 1},
+		{"combining acute", 0x0301, 0},
+		{"devanagari virama", 0x094d, 0},
+		{"devanagari vowel sign", 0x0947, 0},
+		{"hebrew point", 0x05b0, 0},
+		{"arabic fatha", 0x064e, 0},
+		{"thai vowel", 0x0e34, 0},
+		{"zwj", 0x200d, 0},
+		{"vs15", 0xfe0e, 0},
+		{"vs16", 0xfe0f, 0},
+		{"enclosing keycap", 0x20e3, 0},
+		{"cjk", '世', 2},
+		{"hangul", '한', 2},
+		{"halfwidth katakana", 0xff76, 1},
+		{"emoji", 0x1f308, 2},
+		{"skin tone modifier", 0x1f3fd, 2},
+		{"regional indicator", 0x1f1fa, 1},
+		{"musical symbol mark", 0x1d167, 0},
+		{"variation selector supplement", 0xe0100, 0},
+		{"tag character", 0xe0041, 0},
+	}
+
+	for _, tc := range tests {
+		if got := wcRuneWidth(tc.r); got != tc.want {
+			t.Errorf("%s: wcRuneWidth(%U) = %d, want %d", tc.name, tc.r, got, tc.want)
+		}
+	}
+}
+
+// TestWcRuneWidthEastAsian pins that East Asian Ambiguous runes above ASCII
+// honor RUNEWIDTH_EASTASIAN: nothing between printable ASCII and the first
+// combining mark may short-circuit past runewidth.
+func TestWcRuneWidthEastAsian(t *testing.T) {
+	wcOptions.EastAsianWidth = true
+	defer func() { wcOptions.EastAsianWidth = false }()
+
+	for _, r := range []rune{0xa1, 0xb0, 0xd7} {
+		if got := wcRuneWidth(r); got != 2 {
+			t.Errorf("wcRuneWidth(%U) = %d, want 2", r, got)
+		}
+	}
+	if got := StringWidthWc("¡°é"); got != 6 {
+		t.Errorf("StringWidthWc(%q) = %d, want 6", "¡°é", got)
+	}
+}
+
+// TestIsZeroWidthHigh cross-checks the fast path against the Unicode tables
+// over the whole planes above the BMP. The tables' strided ranges interleave
+// when merged, so the lookup must not binary-search them directly.
+func TestIsZeroWidthHigh(t *testing.T) {
+	for r := rune(0x10000); r <= 0x10FFFF; r++ {
+		if want, got := unicode.In(r, zeroWidthTables...), isZeroWidthHigh(r); want != got {
+			t.Errorf("isZeroWidthHigh(%U) = %v, want %v", r, got, want)
+		}
+	}
+}
+
+func BenchmarkStringWidthWcUnicode(b *testing.B) {
+	for _, s := range []string{"नमस्ते दुनिया", "世界你好", "👨‍👩‍👧‍👦 👨‍💻"} {
+		b.Run(s, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = StringWidthWc(s)
+			}
+		})
+	}
+}

--- a/ansi/width.go
+++ b/ansi/width.go
@@ -2,6 +2,7 @@ package ansi
 
 import (
 	"bytes"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/x/ansi/parser"
 )
@@ -88,6 +89,17 @@ func stringWidth(m Method, s string) int {
 	for i := 0; i < len(s); i++ {
 		state, action := parser.Table.Transition(pstate, s[i])
 		if action == parser.PrintAction || state == parser.Utf8State {
+			if m == WcWidth {
+				// Wcwidth sums codepoints, so where the cluster boundaries
+				// fall makes no difference to the total. Skipping the
+				// segmentation is a good deal cheaper.
+				r, size := utf8.DecodeRuneInString(s[i:])
+				width += wcRuneWidth(r)
+				i += size - 1
+				pstate = parser.GroundState
+				continue
+			}
+
 			cluster, w := FirstGraphemeCluster(s[i:], m)
 			width += w
 

--- a/ansi/width_test.go
+++ b/ansi/width_test.go
@@ -21,8 +21,8 @@ var cases = []struct {
 	{"osc", "\x9d2;charmbracelet: ~/Source/bubbletea\x9c", "", 0, 0},
 	{"controlemoji", "\x1b[31m👋\x1b[0m", "👋", 2, 2},
 	{"oscwideemoji", "\x1b]2;title👨‍👩‍👦\x07", "", 0, 0},
-	{"oscwideemoji", "\x1b[31m👨‍👩‍👦\x1b[m", "👨\u200d👩\u200d👦", 2, 2},
-	{"multiemojicsi", "👨‍👩‍👦\x9b38;5;1mhello\x9bm", "👨‍👩‍👦hello", 7, 7},
+	{"oscwideemoji", "\x1b[31m👨‍👩‍👦\x1b[m", "👨\u200d👩\u200d👦", 2, 6},
+	{"multiemojicsi", "👨‍👩‍👦\x9b38;5;1mhello\x9bm", "👨‍👩‍👦hello", 7, 11},
 	{"osc8eastasianlink", "\x9d8;id=1;https://example.com/\x9c打豆豆\x9d8;id=1;\x07", "打豆豆", 6, 6},
 	{"dcsarabic", "\x1bP?123$pسلام\x1b\\اهلا", "اهلا", 4, 4},
 	{"newline", "hello\nworld", "hello\nworld", 10, 10},
@@ -33,8 +33,13 @@ var cases = []struct {
 	{"just_unicode", "Claire’s Boutique", "Claire’s Boutique", 17, 17},
 	{"unclosed_ansi", "Hey, \x1b[7m\n猴", "Hey, \n猴", 7, 7},
 	{"double_asian_runes", " 你\x1b[8m好.", " 你好.", 6, 6},
-	{"flag", "🇸🇦", "🇸🇦", 2, 1},
-	{"half width and ascii", "(ﾟ", "(ﾟ", 1, 1},
+	// Wcwidth measures per codepoint, so the two regional indicators of a
+	// flag take a column each and a ZWJ sequence is as wide as the emoji it
+	// joins. Grapheme width measures the cluster the terminal draws.
+	{"flag", "🇸🇦", "🇸🇦", 2, 2},
+	// The halfwidth voiced sound mark is Extend, so it joins the cluster
+	// before it, but it's a spacing character that advances the cursor.
+	{"half width and ascii", "(ﾟ", "(ﾟ", 1, 2},
 }
 
 func TestStrip(t *testing.T) {


### PR DESCRIPTION
## What?

`FirstGraphemeCluster` measures a cluster under `WcWidth` by handing it to `go-runewidth`'s `StringWidth`, which reports the width of the cluster's first non-zero-width rune. That is a grapheme measurement, not a wcwidth one. It now sums the cluster's codepoints

## Why?

Fixes charmbracelet/bubbletea#1737

___

Fixes CHARM-1896

related charmbracelet/ultraviolet#150