### PR TITLE
fix(golden): preserve line endings across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.ttf filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
+*.golden binary

--- a/exp/golden/golden.go
+++ b/exp/golden/golden.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -42,8 +41,7 @@ func RequireEqual[T []byte | string](tb testing.TB, out T) {
 		tb.Fatal(err)
 	}
 
-	goldenStr := normalizeWindowsLineBreaks(string(goldenBts))
-	goldenStr = escapeSeqs(goldenStr)
+	goldenStr := escapeSeqs(string(goldenBts))
 	outStr := escapeSeqs(string(out))
 
 	diff := udiff.Unified("golden", "run", goldenStr, outStr)
@@ -71,13 +69,4 @@ func escapeSeqs(in string) string {
 		s[i] = q
 	}
 	return strings.Join(s, "\n")
-}
-
-// normalizeWindowsLineBreaks replaces all \r\n with \n.
-// This is needed because Git for Windows checks out with \r\n by default.
-func normalizeWindowsLineBreaks(str string) string {
-	if runtime.GOOS == "windows" {
-		return strings.ReplaceAll(str, "\r\n", "\n")
-	}
-	return str
 }


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features). Not applicable: this is a bug fix for #389.

## What changed

- mark `*.golden` files as binary so Git preserves their bytes on every platform
- remove the Windows-only CRLF normalization workaround from `exp/golden`

## Why

Git for Windows can otherwise rewrite golden fixtures during checkout. Keeping those fixtures byte-for-byte stable fixes the cross-platform behavior at the source instead of normalizing only the expected value at test runtime.

## Verification

- `go build ./...`, `go test -race ./...`, and `go vet ./...` in `exp/golden`
- `go build ./...`, `go test -race ./...`, and `go vet ./...` in `exp/teatest`
- `go build ./...`, `go test -race ./...`, and `go vet ./...` in `exp/teatest/v2`
- checkout simulation with `core.autocrlf=true`: the golden fixture retained zero CRLF sequences and the same SHA-256 digest as the source file

Fixes #389.

Development assistance: OpenAI Codex (GPT-5).
