### PR TITLE
chore(ansi): lint

### DIFF
--- a/ansi/color.go
+++ b/ansi/color.go
@@ -236,7 +236,7 @@ func Convert256(c color.Color) IndexedColor {
 	if colorDist <= grayDist {
 		return IndexedColor(16 + ci) //nolint:gosec
 	}
-	return IndexedColor(232 + greyIdx) //nolint:gosec
+	return IndexedColor(232 + greyIdx)
 
 	// // Is grey or 6x6x6 color closest?
 	// d := distSq(cr, cg, cb, int(r), int(g), int(b))

--- a/ansi/kitty/options.go
+++ b/ansi/kitty/options.go
@@ -12,6 +12,8 @@ var (
 	_ encoding.TextUnmarshaler = &Options{}
 )
 
+// Stringish is a type constraint for types that are either a string or a
+// byte slice.
 type Stringish interface{ string | []byte }
 
 // Options represents a Kitty Graphics Protocol options.
@@ -335,7 +337,7 @@ func (o *Options) UnmarshalText(text []byte) error {
 			case "i":
 				o.ID = v
 			case "q":
-				o.Quiet = byte(v)
+				o.Quiet = byte(v) //nolint:gosec
 			case "p":
 				o.PlacementID = v
 			case "I":

--- a/ansi/mouse.go
+++ b/ansi/mouse.go
@@ -148,7 +148,7 @@ const x10Offset = 32
 //
 // See: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#Mouse%20Tracking
 func MouseX10(b byte, x, y int) string {
-	return "\x1b[M" + string(b+x10Offset) + string(byte(x)+x10Offset+1) + string(byte(y)+x10Offset+1)
+	return "\x1b[M" + string(b+x10Offset) + string(byte(x)+x10Offset+1) + string(byte(y)+x10Offset+1) //nolint:gosec
 }
 
 // MouseSgr returns an escape sequence representing a mouse event in SGR mode.

--- a/ansi/parser/transition_table.go
+++ b/ansi/parser/transition_table.go
@@ -52,7 +52,7 @@ func (t TransitionTable) AddMany(codes []byte, state State, action Action, next 
 // AddRange adds a range of transitions.
 func (t TransitionTable) AddRange(start, end byte, state State, action Action, next State) {
 	for i := int(start); i <= int(end); i++ {
-		t.AddOne(byte(i), state, action, next)
+		t.AddOne(byte(i), state, action, next) //nolint:gosec
 	}
 }
 
@@ -67,7 +67,7 @@ func (t TransitionTable) Transition(state State, code byte) (State, Action) {
 func r(start, end byte) []byte {
 	var a []byte
 	for i := int(start); i <= int(end); i++ {
-		a = append(a, byte(i))
+		a = append(a, byte(i)) //nolint:gosec
 	}
 	return a
 }

--- a/ansi/parser_decode.go
+++ b/ansi/parser_decode.go
@@ -460,7 +460,7 @@ type Cmd int
 // range of 0x3C-0x3F.
 // Zero is returned if the sequence does not have a prefix.
 func (c Cmd) Prefix() byte {
-	return byte(parser.Prefix(int(c)))
+	return byte(parser.Prefix(int(c))) //nolint:gosec
 }
 
 // Intermediate returns the unpacked intermediate byte of the CSI sequence.
@@ -469,12 +469,12 @@ func (c Cmd) Prefix() byte {
 // ',', '-', '.', '/'.
 // Zero is returned if the sequence does not have an intermediate byte.
 func (c Cmd) Intermediate() byte {
-	return byte(parser.Intermediate(int(c)))
+	return byte(parser.Intermediate(int(c))) //nolint:gosec
 }
 
 // Final returns the unpacked command byte of the CSI sequence.
 func (c Cmd) Final() byte {
-	return byte(parser.Command(int(c)))
+	return byte(parser.Command(int(c))) //nolint:gosec
 }
 
 // Command packs a command with the given prefix, intermediate, and final. A

--- a/ansi/sixel/encoder.go
+++ b/ansi/sixel/encoder.go
@@ -136,7 +136,7 @@ func (s *sixelBuilder) SetColor(x int, y int, color color.Color) {
 	paletteIndex := s.SixelPalette.ColorIndex(sixelConvertColor(color))
 
 	bit := s.BandHeight()*s.imageWidth*6*paletteIndex + bandY*s.imageWidth*6 + (x * 6) + (y % 6)
-	s.pixelBands.Set(uint(bit)) //nolint:gosec
+	s.pixelBands.Set(uint(bit))
 }
 
 // GeneratePixels is used to write the pixel data to the internal imageData string builder.
@@ -166,8 +166,8 @@ func (s *sixelBuilder) GeneratePixels() string {
 				continue
 			}
 
-			firstColorBit := uint(s.BandHeight()*s.imageWidth*6*paletteIndex + bandY*s.imageWidth*6) //nolint:gosec
-			nextColorBit := firstColorBit + uint(s.imageWidth*6)                                     //nolint:gosec
+			firstColorBit := uint(s.BandHeight()*s.imageWidth*6*paletteIndex + bandY*s.imageWidth*6)
+			nextColorBit := firstColorBit + uint(s.imageWidth*6)
 
 			firstSetBitInBand, anySet := s.pixelBands.NextSet(firstColorBit)
 			if !anySet || firstSetBitInBand >= nextColorBit {
@@ -183,7 +183,7 @@ func (s *sixelBuilder) GeneratePixels() string {
 			s.writeControlRune(ColorIntroducer)
 			s.imageData.WriteString(strconv.Itoa(paletteIndex))
 			for x := 0; x < s.imageWidth; x += 4 {
-				bit := firstColorBit + uint(x*6) //nolint:gosec
+				bit := firstColorBit + uint(x*6)
 				word := s.pixelBands.GetWord64AtBit(bit)
 
 				pixel1 := byte((word & 63) + '?')

--- a/ansi/sixel/palette.go
+++ b/ansi/sixel/palette.go
@@ -189,7 +189,7 @@ func (p *sixelPalette) quantize(uniqueColors []sixelColor, pixelCounts map[sixel
 		// Then can delete palette_sort.go
 		sortFunc(uniqueColors[cubeToSplit.startIndex:cubeToSplit.startIndex+cubeToSplit.length],
 			func(left sixelColor, right sixelColor) int {
-				switch cubeToSplit.sliceChannel { //nolint:exhaustive // alpha channel not used
+				switch cubeToSplit.sliceChannel { // alpha channel not used
 				case quantizationRed:
 					return compare(left.Red, right.Red)
 				case quantizationGreen:

--- a/ansi/sixel/palette_sort.go
+++ b/ansi/sixel/palette_sort.go
@@ -74,7 +74,7 @@ func (r *xorshift) Next() uint64 {
 }
 
 func nextPowerOfTwo(length int) uint {
-	return 1 << bits.Len(uint(length)) //nolint:gosec
+	return 1 << bits.Len(uint(length))
 }
 
 // insertionSortCmpFunc sorts data[a:b] using insertion sort.
@@ -315,7 +315,7 @@ func breakPatternsCmpFunc[E any](data []E, a, b int) {
 		modulus := nextPowerOfTwo(length)
 
 		for idx := a + (length/4)*2 - 1; idx <= a+(length/4)*2+1; idx++ {
-			other := int(uint(random.Next()) & (modulus - 1)) //nolint:gosec
+			other := int(uint(random.Next()) & (modulus - 1))
 			if other >= length {
 				other -= length
 			}


### PR DESCRIPTION
Removes unneeded `//nolint:gosec` (`nolintlint`) and adds `//nolint:gosec` on false positives