### PR TITLE
fix(vt): keep OSC 8 hyperlinks when the URL contains semicolons

### DIFF
--- a/vt/hyperlink_test.go
+++ b/vt/hyperlink_test.go
@@ -1,0 +1,36 @@
+package vt
+
+import "testing"
+
+// TestHyperlinkURLWithSemicolon verifies that an OSC 8 hyperlink whose URI
+// contains a semicolon is kept and attached to the cells, rather than being
+// silently dropped. URLs may legally contain semicolons (for example in query
+// strings or path parameters), and only the first two semicolons of the OSC 8
+// payload are field separators.
+//
+// The assertion is agnostic to whether the URI lands in Link.URL or
+// Link.Params: the exchange of those two fields is a separate bug tracked by
+// PR #868, and this test only checks that the URI survives the parser at all.
+func TestHyperlinkURLWithSemicolon(t *testing.T) {
+	const uri = "https://example.com/f?a=1;b=2"
+
+	term := newTestTerminal(t, 10, 1)
+	// Set the hyperlink, write "AB", then reset the hyperlink, matching the
+	// reproduction from the issue: OSC 8 ; ; <uri> ST  AB  OSC 8 ; ; ST.
+	term.Write([]byte("\x1b]8;;" + uri + "\x1b\\AB\x1b]8;;\x1b\\"))
+
+	for _, x := range []int{0, 1} {
+		cell := term.CellAt(x, 0)
+		if cell == nil {
+			t.Fatalf("expected a cell at (%d, 0)", x)
+		}
+		got := cell.Link.URL
+		if got != uri {
+			got = cell.Link.Params
+		}
+		if got != uri {
+			t.Errorf("OSC 8 hyperlink with a semicolon in the URI was dropped at (%d, 0):\nwant URI %q in Link.URL or Link.Params\ngot  URL=%q Params=%q",
+				x, uri, cell.Link.URL, cell.Link.Params)
+		}
+	}
+}

--- a/vt/osc.go
+++ b/vt/osc.go
@@ -125,7 +125,11 @@ func (e *Emulator) handleWorkingDirectory(cmd int, data []byte) {
 }
 
 func (e *Emulator) handleHyperlink(cmd int, data []byte) {
-	parts := bytes.Split(data, []byte{';'})
+	// An OSC 8 payload is "8;params;uri". Only the first two semicolons are
+	// field separators; any later semicolons are part of the URI (URLs may
+	// legally contain them, e.g. in query strings or path parameters). Use
+	// SplitN so the URI keeps its own semicolons instead of being rejected.
+	parts := bytes.SplitN(data, []byte{';'}, 3)
 	if len(parts) != 3 || cmd != 8 {
 		// Invalid, ignore
 		return


### PR DESCRIPTION
## Summary

Fixes #937.

An OSC 8 hyperlink is silently dropped when its URI contains a semicolon (for example `https://example.com/f?a=1;b=2`). The link text still renders, but the cells are never given the hyperlink, so it is not clickable.

## Root cause

`handleHyperlink` in `vt/osc.go` split the payload on *every* semicolon:

    parts := bytes.Split(data, []byte{';'})
    if len(parts) != 3 || cmd != 8 { return }

The OSC 8 wire format is `8 ; params ; uri`, where only the first two semicolons are field separators -- any later semicolon belongs to the URI. A URI with a semicolon produces four or more parts, so the `len(parts) != 3` guard rejects the whole command and the link is discarded.

## Fix

Split on only the first two semicolons with `bytes.SplitN(data, ';', 3)`, so the remainder (the URI) keeps its own semicolons. The `len(parts) != 3` guard still rejects malformed payloads with fewer than two semicolons, and the reset sequence (`8;;`) and ordinary links are unaffected.

This is orthogonal to #868: that PR corrects which slot the params and URI are stored in (they are currently exchanged), while this PR fixes the parser dropping semicolon URIs entirely. The two changes compose -- the field mapping is left to #868. The added test asserts the URI survives in either `Link.URL` or `Link.Params`, so it passes independently of #868's merge order.

## Test

`TestHyperlinkURLWithSemicolon` drives `Emulator.Write` with the issue's reproduction and asserts the semicolon URI reaches the cells' link.

- RED (before fix): link dropped, `Link.URL`/`Link.Params` both empty -- FAIL.
- GREEN (after fix): URI present -- PASS.

Full `vt` suite passes; `gofmt` and `go vet` clean.

---
AI-assisted: this change was prepared with the help of an AI coding assistant and reviewed by me.