### PR TITLE
feat(vt): implement IRM insert mode

### DIFF
--- a/vt/emulator_test.go
+++ b/vt/emulator_test.go
@@ -2,6 +2,7 @@ package vt
 
 import (
 	"testing"
+	"time"
 
 	uv "github.com/charmbracelet/ultraviolet"
 )
@@ -1783,6 +1784,124 @@ var cases = []struct {
 		want: []string{"                       "},
 		pos:  uv.Pos(22, 0),
 	},
+
+	// Insert/Replace Mode [ansi.ModeInsertReplace]
+	{
+		// Replace is the default: the printed cell lands on top of what is
+		// already there.
+		name: "IRM Reset Overwrites",
+		w:    10, h: 1,
+		input: []string{
+			"abc",
+			"\x1b[3D", // back to column 0
+			"X",
+		},
+		want: []string{"Xbc       "},
+		pos:  uv.Pos(1, 0),
+	},
+	{
+		// With IRM set the line shifts right instead, so the same sequence
+		// renders like an ICH of 1 followed by the character.
+		name: "IRM Set Shifts Line Right",
+		w:    10, h: 1,
+		input: []string{
+			"abc",
+			"\x1b[3D",
+			"\x1b[4h", // set IRM
+			"X",
+			"\x1b[4l", // reset IRM
+		},
+		want: []string{"Xabc      "},
+		pos:  uv.Pos(1, 0),
+	},
+	{
+		name: "IRM Set Shifts Once Per Character",
+		w:    10, h: 1,
+		input: []string{
+			"abc",
+			"\x1b[3D",
+			"\x1b[4h",
+			"XY",
+		},
+		want: []string{"XYabc     "},
+		pos:  uv.Pos(2, 0),
+	},
+	{
+		// A wide grapheme has to open a gap as wide as it is, or it lands on
+		// half of the character it displaced.
+		name: "IRM Set Wide Grapheme Opens Two Cells",
+		w:    10, h: 1,
+		input: []string{
+			"abc",
+			"\x1b[3D",
+			"\x1b[4h",
+			"世",
+		},
+		want: []string{"世abc     "},
+		pos:  uv.Pos(2, 0),
+	},
+	{
+		// Cells pushed past the right edge are lost, they do not wrap.
+		name: "IRM Set Pushes Cells Off The Right Edge",
+		w:    5, h: 1,
+		input: []string{
+			"abcde",
+			"\x1b[5D",
+			"\x1b[4h",
+			"X",
+		},
+		want: []string{"Xabcd"},
+		pos:  uv.Pos(1, 0),
+	},
+	{
+		// The gap opens where the character actually lands, which after a wrap
+		// is column 0 of the next line — not where the cursor still sits, at
+		// the edge of the line just filled.
+		name: "IRM Set Inserts At The Wrapped Position",
+		w:    5, h: 2,
+		input: []string{
+			"\x1b[2;1H", // row 1
+			"xy",
+			"\x1b[1;1H", // row 0
+			"abcde",     // fills row 0, leaving the cursor pending-wrap
+			"\x1b[4h",
+			"Z", // wraps to row 1 and inserts there
+		},
+		want: []string{"abcde", "Zxy  "},
+		pos:  uv.Pos(1, 1),
+	},
+	{
+		// The vertical scrolling region bounds what scrolls, not what a
+		// character printed under insert mode shifts: a line outside the region
+		// still opens a gap. Without this the mode would quietly degrade to
+		// replace on those lines, since the cell is printed either way.
+		name: "IRM Set Inserts Outside The Scroll Region",
+		w:    10, h: 3,
+		input: []string{
+			"\x1b[2;3r", // scrolling region is rows 2-3
+			"\x1b[1;1H", // row 1, outside it
+			"abc",
+			"\x1b[1;1H",
+			"\x1b[4h",
+			"X",
+		},
+		want: []string{"Xabc      ", "          ", "          "},
+		pos:  uv.Pos(1, 0),
+	},
+	{
+		// IRM is an ANSI mode, so RIS returns it to its reset default.
+		name: "IRM Cleared By RIS",
+		w:    10, h: 1,
+		input: []string{
+			"\x1b[4h",
+			"\x1bc", // RIS
+			"abc",
+			"\x1b[3D",
+			"X",
+		},
+		want: []string{"Xbc       "},
+		pos:  uv.Pos(1, 0),
+	},
 }
 
 // TestTerminal tests the terminal.
@@ -1825,4 +1944,51 @@ func termText(term *Emulator) []string {
 		lines = append(lines, line)
 	}
 	return lines
+}
+
+// TestIRMModeReport checks that IRM is a mode the emulator knows about: DECRQM
+// has to answer set/reset for it rather than "not recognised", which is what a
+// program asks before it trusts insert mode.
+func TestIRMModeReport(t *testing.T) {
+	term := newTestTerminal(t, 10, 1)
+
+	// The emulator writes its replies into a pipe, so something has to be
+	// reading while the request is written or the write blocks. Reading is what
+	// runs in the goroutine: every Write stays on this one, because concurrent
+	// writes race on the parser state.
+	replies := make(chan string, 2)
+	go func() {
+		for {
+			buf := make([]byte, 32)
+			n, err := term.Read(buf)
+			if err != nil {
+				close(replies)
+				return
+			}
+			replies <- string(buf[:n])
+		}
+	}()
+
+	next := func() string {
+		select {
+		case reply, ok := <-replies:
+			if !ok {
+				t.Fatal("emulator closed before replying")
+			}
+			return reply
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for a mode report")
+			return ""
+		}
+	}
+
+	term.Write([]byte("\x1b[4$p")) //nolint:errcheck // writing to an emulator cannot fail
+	if got, want := next(), "\x1b[4;2$y"; got != want {
+		t.Errorf("DECRQM before setting IRM: got %q, want %q (2 = reset)", got, want)
+	}
+
+	term.Write([]byte("\x1b[4h\x1b[4$p")) //nolint:errcheck // writing to an emulator cannot fail
+	if got, want := next(), "\x1b[4;1$y"; got != want {
+		t.Errorf("DECRQM after setting IRM: got %q, want %q (1 = set)", got, want)
+	}
 }

--- a/vt/mode.go
+++ b/vt/mode.go
@@ -6,6 +6,7 @@ import "github.com/charmbracelet/x/ansi"
 func (e *Emulator) resetModes() {
 	e.modes = ansi.Modes{
 		// Recognized modes and their default values.
+		ansi.ModeInsertReplace:       ansi.ModeReset, // 4
 		ansi.ModeCursorKeys:          ansi.ModeReset, // ?1
 		ansi.ModeOrigin:              ansi.ModeReset, // ?6
 		ansi.ModeAutoWrap:            ansi.ModeSet,   // ?7

--- a/vt/screen.go
+++ b/vt/screen.go
@@ -283,6 +283,24 @@ func (s *Screen) InsertCell(n int) {
 	s.buf.InsertCellArea(x, y, n, s.blankCell(), s.scroll)
 }
 
+// insertCellsInRow inserts n blank characters at the given position, pushing
+// out cells to the right and out of the screen. It differs from
+// [Screen.InsertCell] in two ways, both of which a print under insert mode
+// needs: the position is passed in rather than read from the cursor, because a
+// print that wrapped lands on the next line while the cursor still sits at the
+// edge of the last one; and only the left and right margins bound the shift,
+// because the line a character prints on shifts whether or not that line is
+// inside the vertical scrolling region.
+func (s *Screen) insertCellsInRow(x, y, n int) {
+	if n <= 0 {
+		return
+	}
+
+	row := s.scroll
+	row.Min.Y, row.Max.Y = y, y+1
+	s.buf.InsertCellArea(x, y, n, s.blankCell(), row)
+}
+
 // DeleteCell deletes n cells at the cursor position moving cells to the left.
 // This has no effect if the cursor is outside the scroll region.
 func (s *Screen) DeleteCell(n int) {

--- a/vt/utf8.go
+++ b/vt/utf8.go
@@ -85,6 +85,15 @@ func (e *Emulator) handleGrapheme(content string, width int) {
 		e.lastChar, _ = utf8.DecodeRuneInString(content)
 	}
 
+	// IRM: while insert mode is set, a printed grapheme opens a gap at the
+	// cursor and pushes the rest of the line right instead of overwriting it,
+	// which is the same effect as an [ansi.ICH] of one immediately before the
+	// character. The gap is as wide as the grapheme, so a wide character does
+	// not come to rest on half of the cell it displaced.
+	if e.isModeSet(ansi.ModeInsertReplace) {
+		e.scr.insertCellsInRow(x, y, cell.Width)
+	}
+
 	e.scr.SetCell(x, y, &cell)
 
 	// Handle phantom state at the end of the line


### PR DESCRIPTION
Fixes #949.

`vt` implemented ICH (`CSI n @`) but not IRM (`CSI 4 h` / `CSI 4 l`). Mode 4 was missing from the table in `resetModes`, so `handleMode` stored it and nothing read it back, and `handleGrapheme` always wrote over the cell under the cursor. The issue's repro, before and after:

```
ICH  (CSI n @)   got="Xabc"   want="Xabc"
IRM  (CSI 4 h)   got="Xbc"    want="Xabc"     <- before
IRM  (CSI 4 h)   got="Xabc"   want="Xabc"     <- after
```

Thanks @cmj0121 for the writeup — the diagnosis and the suggested shape are yours; this follows it with two adjustments noted below.

## What changed

- `vt/mode.go` — `ansi.ModeInsertReplace` joins the recognised-mode table at its reset default, so the mode is tracked and DECRQM answers set/reset (`\x1b[4;2$y` / `\x1b[4;1$y`) instead of "not recognised" (`\x1b[4;0$y`).
- `vt/utf8.go` — while the mode is set, a printed grapheme opens a gap at its own position before the cell is written. The gap is `cell.Width` wide, so a wide character does not come to rest on half of the cell it displaced.
- `vt/screen.go` — the insertion goes through a new unexported `insertCellsInRow`. `Screen.InsertCell` and the ICH handler are untouched.

## Two deviations from the issue's suggestion, both deliberate

**1. Position instead of the cursor.** `Screen.InsertCell` reads `s.cur`, which is the wrong place for a print that has just wrapped: the cursor still sits at the edge of the line just filled while the cell goes to column 0 of the next one. `insertCellsInRow` takes the position `handleGrapheme` has already computed. Covered by "IRM Set Inserts At The Wrapped Position" — with the cursor-based call that test renders `"Zy   "` instead of `"Zxy  "`.

**2. Bounded by the left and right margins only.** `InsertCellArea` refuses to shift a row outside the rectangle it is given, so passing the scroll region would have made insert mode silently degrade to replace on any line outside `DECSTBM` — silently, because the cell prints either way. The line a character prints on shifts whether or not it falls inside the vertical scrolling region, so `insertCellsInRow` narrows the scroll rectangle to the target row and keeps its horizontal bounds. Covered by "IRM Set Inserts Outside The Scroll Region".

Happy to align it with whatever you prefer if ICH's current region gating is intentional and you would rather both behave the same.

## Tests

Eight cases in the existing `cases` table plus one for the mode report: replace as the default, a single insert, repeated inserts, a wide grapheme opening two cells, cells pushed off the right edge, insertion at the wrapped position, insertion outside the scrolling region, `RIS` clearing the mode, and the DECRQM answer before and after `CSI 4 h`.

Each one was checked against a deliberately broken implementation to make sure it fails for the right reason — dropping the mode-table entry, using the cursor-based insert, and using the scroll rectangle each turn the corresponding test red.

Verified with `go test ./... -race -count=3 -shuffle=on` in `vt/`, and `golangci-lint run --config ../.golangci.yml ./...` reports only the two findings already present on `main` (`emulator.go:421`, `csi.go:39`), both in files this PR does not touch. `vttest` still builds against the change.

## One thing I noticed but did not fix

Printing onto the right half of a wide cell under IRM leaves an orphaned zero-width cell in the line, which will spin any loop that walks a line by `cell.Width` — including this package's own `termText` test helper. That is not new here: ICH produces the identical shape today, since both go through `ultraviolet`'s buffer shift. It seemed like its own issue rather than something to fold into this one, but say the word and I will take it.
