### PR TITLE
fix(vt): report cursor state a reset changes

### DIFF
--- a/vt/emulator_test.go
+++ b/vt/emulator_test.go
@@ -1826,3 +1826,131 @@ func termText(term *Emulator) []string {
 	}
 	return lines
 }
+
+// TestCursorVisibilityOnReset checks that a reset which makes the cursor
+// visible again tells the consumer. Visibility is only observable through the
+// callback, so a silent change leaves a renderer drawing a hidden cursor until
+// some later application happens to show it.
+func TestCursorVisibilityOnReset(t *testing.T) {
+	term := newTestTerminal(t, 20, 2)
+
+	visible := true
+	var calls int
+	term.SetCallbacks(Callbacks{
+		CursorVisibility: func(v bool) {
+			visible = v
+			calls++
+		},
+	})
+
+	term.Write([]byte("\x1b[?25l")) //nolint:errcheck // writing to an emulator cannot fail
+	if visible {
+		t.Fatal("hiding the cursor did not report it")
+	}
+
+	before := calls
+	term.Write([]byte("\x1bc")) //nolint:errcheck // writing to an emulator cannot fail
+	if !visible {
+		t.Error("RIS left the tracked cursor hidden; the emulator's is visible")
+	}
+	if calls != before+1 {
+		t.Errorf("RIS reported visibility %d times, want exactly 1", calls-before)
+	}
+}
+
+// TestCursorVisibilityUnchangedOnReset checks the other half: a reset that does
+// not change visibility must stay quiet rather than report a no-op change.
+func TestCursorVisibilityUnchangedOnReset(t *testing.T) {
+	term := newTestTerminal(t, 20, 2)
+
+	var calls int
+	term.SetCallbacks(Callbacks{
+		CursorVisibility: func(bool) { calls++ },
+	})
+
+	term.Write([]byte("\x1bc")) //nolint:errcheck // writing to an emulator cannot fail
+	if calls != 0 {
+		t.Errorf("reset with an already-visible cursor reported %d times, want 0", calls)
+	}
+}
+
+// TestCursorVisibilityResetFromAltScreen checks that a reset is one event to a
+// consumer. Several paths inside a reset touch visibility — leaving the
+// alternate screen reports it unconditionally — and reporting each of them
+// would make a single reset look like a burst of changes.
+func TestCursorVisibilityResetFromAltScreen(t *testing.T) {
+	term := newTestTerminal(t, 20, 2)
+
+	var calls int
+	term.SetCallbacks(Callbacks{CursorVisibility: func(bool) { calls++ }})
+
+	term.Write([]byte("\x1b[?1049h")) //nolint:errcheck // writing to an emulator cannot fail
+	term.Write([]byte("\x1b[?25l"))   //nolint:errcheck // writing to an emulator cannot fail
+
+	before := calls
+	term.Write([]byte("\x1bc")) //nolint:errcheck // writing to an emulator cannot fail
+	if got := calls - before; got != 1 {
+		t.Errorf("reset from the alternate screen reported visibility %d times, want 1", got)
+	}
+}
+
+// TestCursorStateReportedOnReset covers the other two properties a reset
+// silently returns to their defaults. A consumer that draws the cursor tracks
+// each through its callback, so a reset that moves it home and clears its style
+// without saying so leaves that consumer drawing a stale cursor.
+func TestCursorStateReportedOnReset(t *testing.T) {
+	term := newTestTerminal(t, 20, 5)
+
+	var (
+		moves  []uv.Position
+		styles int
+	)
+	term.SetCallbacks(Callbacks{
+		CursorPosition: func(_, to uv.Position) { moves = append(moves, to) },
+		CursorStyle:    func(CursorStyle, bool) { styles++ },
+	})
+
+	term.Write([]byte("\x1b[4;6H")) //nolint:errcheck // writing to an emulator cannot fail
+	term.Write([]byte("\x1b[3 q"))  //nolint:errcheck // blinking underline
+	moves, styles = nil, 0
+
+	term.Write([]byte("\x1bc")) //nolint:errcheck // writing to an emulator cannot fail
+
+	if want := []uv.Position{uv.Pos(0, 0)}; len(moves) != 1 || moves[0] != want[0] {
+		t.Errorf("RIS reported cursor positions %v, want %v", moves, want)
+	}
+	if styles != 1 {
+		t.Errorf("RIS reported the cursor style %d times, want 1", styles)
+	}
+}
+
+// TestCursorCallbacksSurviveAPanickingCallback checks that the mute applied for
+// the duration of a reset is lifted even when a callback panics part-way
+// through and the caller recovers, rather than silencing the cursor for good.
+func TestCursorCallbacksSurviveAPanickingCallback(t *testing.T) {
+	term := newTestTerminal(t, 20, 2)
+
+	var visibility int
+	count := func(bool) { visibility++ }
+
+	term.SetCallbacks(Callbacks{CursorVisibility: count})
+	term.Write([]byte("\x1b[?1049h")) //nolint:errcheck // writing to an emulator cannot fail
+
+	// Armed only now, so the panic happens while leaving the alternate screen
+	// during the reset — that is, after the callbacks have been muted.
+	term.SetCallbacks(Callbacks{
+		AltScreen:        func(bool) { panic("callback blew up") },
+		CursorVisibility: count,
+	})
+
+	func() {
+		defer func() { _ = recover() }()
+		term.Write([]byte("\x1bc")) //nolint:errcheck // writing to an emulator cannot fail
+	}()
+
+	visibility = 0
+	term.Write([]byte("\x1b[?25l")) //nolint:errcheck // writing to an emulator cannot fail
+	if visibility != 1 {
+		t.Errorf("hiding the cursor after a panicking reset reported %d times, want 1", visibility)
+	}
+}

--- a/vt/esc.go
+++ b/vt/esc.go
@@ -22,6 +22,41 @@ func (e *Emulator) handleEsc(cmd ansi.Cmd) {
 
 // fullReset performs a full terminal reset as in [ansi.RIS].
 func (e *Emulator) fullReset() {
+	// A reset returns the cursor to a visible, unstyled, home-position state,
+	// and nothing along the way reports any of that: [Screen.Reset] assigns a
+	// zero Cursor rather than going through the setters that carry the
+	// callbacks, and by the time the mode table is restored the values already
+	// match. Those three properties are only observable through their
+	// callbacks, so a consumer drawing the cursor would keep drawing a hidden
+	// one, in the wrong place, in the wrong style, until some later application
+	// happened to change each.
+	//
+	// The callbacks are muted for the reset and each change reported once at
+	// the end. Several paths in here touch the cursor — leaving the alternate
+	// screen reports visibility unconditionally, for one — and a reset is one
+	// event to a consumer, not a burst.
+	was, cb := e.scr.cur, e.cb
+	e.cb.CursorVisibility, e.cb.CursorPosition, e.cb.CursorStyle = nil, nil, nil
+
+	defer func() {
+		// Restored in a defer so a panic in one of the callbacks fired during
+		// the reset, recovered by the caller, cannot leave them muted for good.
+		e.cb.CursorVisibility = cb.CursorVisibility
+		e.cb.CursorPosition = cb.CursorPosition
+		e.cb.CursorStyle = cb.CursorStyle
+
+		cur := e.scr.cur
+		if cb.CursorVisibility != nil && cur.Hidden != was.Hidden {
+			cb.CursorVisibility(!cur.Hidden)
+		}
+		if cb.CursorPosition != nil && cur.Position != was.Position {
+			cb.CursorPosition(was.Position, cur.Position)
+		}
+		if cb.CursorStyle != nil && (cur.Style != was.Style || cur.Steady != was.Steady) {
+			cb.CursorStyle(cur.Style, !cur.Steady)
+		}
+	}()
+
 	e.scrs[0].Reset()
 	e.scrs[1].Reset()
 	e.resetTabStops()


### PR DESCRIPTION
Fixes #936.

`Screen.Reset` assigns a zero `Cursor` rather than going through the setters that carry the callbacks, and by the time `resetModes` restores the mode table the values already match — so nothing reports the change:

```go
emu.Write([]byte("\x1b[?25l")) // CursorVisibility(false)
emu.Write([]byte("\x1bc"))     // cursor is visible again, silently
```

## Scope

The issue is about visibility. Position and style are the same bug in the same function — RIS sends the cursor home and clears its style just as silently — so this covers all three. Verified before the change: a cursor moved to (5,3) with a blinking-underline style reports 0 position changes and 0 style changes across a reset. Happy to trim it back to visibility alone if you would rather keep the change narrow.

I went with reporting rather than adding a getter, since it needs no new API and matches how the other cursor state is already observed. A `CursorVisible()` getter would also solve the issue if you would prefer that shape.

## Why the callbacks are muted during the reset

Several paths inside a reset touch the cursor, and `setAltScreenMode` reports visibility *unconditionally* — even when it has not changed. Reporting each of them would turn one reset into a burst of changes, and a reset arriving from the alternate screen would report visibility twice. So the three cursor callbacks are muted for the duration and each real change reported once at the end.

Restoring them happens in a `defer`. Without it, a callback that panics mid-reset — `AltScreen` fires in there — and is recovered by the caller would leave the cursor callbacks nil permanently, silencing every later change. There is a test for exactly that.

## Tests

- visibility reported once after a reset that changes it
- no report when the cursor was already visible
- exactly one report when the reset also leaves the alternate screen
- position and style each reported once
- callbacks still work after a panicking callback during a reset

Each was checked against a deliberately broken version to be sure it fails for the right reason: dropping the report, and turning the `defer` into a plain call at the end, each turn the matching test red.

`go test ./... -race -count=3 -shuffle=on` passes; `golangci-lint run --config ../.golangci.yml ./...` reports only the two findings already on `main` (`emulator.go:421`, `csi.go:39`), in files this PR does not touch.

## Noticed, not fixed

`setAltScreenMode` reports `CursorVisibility` on every screen switch whether or not visibility changed, unlike `setCursorHidden` which checks first. That is what forced the muting here rather than a simple compare. It looked like its own change to make, but I am happy to fold it in.
