### PR TITLE
fix(vt): stop terminal queries blocking Emulator.Write

### DIFF
--- a/vt/csi.go
+++ b/vt/csi.go
@@ -2,7 +2,6 @@ package vt
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/charmbracelet/x/ansi"
@@ -27,7 +26,7 @@ func (e *Emulator) handleRequestMode(params ansi.Params, isAnsi bool) {
 	}
 
 	setting := e.modes[mode]
-	_, _ = io.WriteString(e.pw, ansi.ReportMode(mode, setting))
+	_, _ = writeReplyString(e.replies, ansi.ReportMode(mode, setting))
 }
 
 func paramsString(cmd ansi.Cmd, params ansi.Params) string {

--- a/vt/csi_mode.go
+++ b/vt/csi_mode.go
@@ -92,7 +92,7 @@ func (e *Emulator) setMode(mode ansi.Mode, setting ansi.ModeSetting) {
 		e.setAltScreenMode(setting.IsSet())
 	case ansi.ModeInBandResize:
 		if setting.IsSet() {
-			_, _ = io.WriteString(e.pw, ansi.InBandResize(e.Height(), e.Width(), 0, 0))
+			_, _ = io.WriteString(e.replies, ansi.InBandResize(e.Height(), e.Width(), 0, 0))
 		}
 	}
 	if setting.IsSet() {

--- a/vt/emulator.go
+++ b/vt/emulator.go
@@ -3,6 +3,7 @@ package vt
 import (
 	"image/color"
 	"io"
+	"sync/atomic"
 
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/ultraviolet/screen"
@@ -59,16 +60,17 @@ type Emulator struct {
 	// tabstop is the list of tab stops.
 	tabstops *uv.TabStops
 
-	// I/O pipes.
-	pr *io.PipeReader
-	pw *io.PipeWriter
+	// replies carries what the emulator says back to its driver.
+	replies *replyBuffer
 
 	// The GL and GR character set identifiers.
 	gl, gr  int
 	gsingle int // temporarily select GL or GR
 
 	// Indicates if the terminal is closed.
-	closed bool
+	// closed is atomic because Close is the only way to wake a reader parked in
+	// Read, so it is read from one goroutine while another closes.
+	closed atomic.Bool
 
 	// atPhantom indicates if the cursor is out of bounds.
 	// When true, and a character is written, the cursor is moved to the next line.
@@ -99,7 +101,7 @@ func NewEmulator(w, h int) *Emulator {
 		HandlePm:  t.handlePm,
 		HandleSos: t.handleSos,
 	})
-	t.pr, t.pw = io.Pipe()
+	t.replies = newReplyBuffer()
 	t.resetModes()
 	t.tabstops = uv.DefaultTabStops(w)
 	t.registerDefaultHandlers()
@@ -243,32 +245,31 @@ func (e *Emulator) Resize(width int, height int) {
 	e.setCursor(x, y)
 
 	if e.isModeSet(ansi.ModeInBandResize) {
-		_, _ = io.WriteString(e.pw, ansi.InBandResize(e.Height(), e.Width(), 0, 0))
+		_, _ = io.WriteString(e.replies, ansi.InBandResize(e.Height(), e.Width(), 0, 0))
 	}
 }
 
 // Read reads data from the terminal input buffer.
 func (e *Emulator) Read(p []byte) (n int, err error) {
-	if e.closed {
+	if e.closed.Load() {
 		return 0, io.EOF
 	}
 
-	return e.pr.Read(p) //nolint:wrapcheck
+	return e.replies.Read(p)
 }
 
 // Close closes the terminal.
 func (e *Emulator) Close() error {
-	if e.closed {
+	if e.closed.Swap(true) {
 		return nil
 	}
 
-	e.closed = true
-	return e.pw.CloseWithError(io.EOF) //nolint:wrapcheck
+	return e.replies.Close()
 }
 
 // Write writes data to the terminal output buffer.
 func (e *Emulator) Write(p []byte) (n int, err error) {
-	if e.closed {
+	if e.closed.Load() {
 		return 0, io.ErrClosedPipe
 	}
 
@@ -295,7 +296,7 @@ func (e *Emulator) WriteString(s string) (n int, err error) {
 // InputPipe returns the terminal's input pipe.
 // This can be used to send input to the terminal.
 func (e *Emulator) InputPipe() io.Writer {
-	return e.pw
+	return e.replies
 }
 
 // Paste pastes text into the terminal.
@@ -303,16 +304,16 @@ func (e *Emulator) InputPipe() io.Writer {
 // appropriate escape sequences.
 func (e *Emulator) Paste(text string) {
 	if e.isModeSet(ansi.ModeBracketedPaste) {
-		_, _ = io.WriteString(e.pw, ansi.BracketedPasteStart)
-		defer io.WriteString(e.pw, ansi.BracketedPasteEnd) //nolint:errcheck
+		_, _ = io.WriteString(e.replies, ansi.BracketedPasteStart)
+		defer io.WriteString(e.replies, ansi.BracketedPasteEnd) //nolint:errcheck
 	}
 
-	_, _ = io.WriteString(e.pw, text)
+	_, _ = io.WriteString(e.replies, text)
 }
 
 // SendText sends arbitrary text to the terminal.
 func (e *Emulator) SendText(text string) {
-	_, _ = io.WriteString(e.pw, text)
+	_, _ = io.WriteString(e.replies, text)
 }
 
 // SendKeys sends multiple keys to the terminal.

--- a/vt/focus.go
+++ b/vt/focus.go
@@ -21,9 +21,9 @@ func (e *Emulator) Blur() {
 func (e *Emulator) focus(focus bool) {
 	if mode, ok := e.modes[ansi.ModeFocusEvent]; ok && mode.IsSet() {
 		if focus {
-			_, _ = io.WriteString(e.pw, ansi.Focus)
+			_, _ = io.WriteString(e.replies, ansi.Focus)
 		} else {
-			_, _ = io.WriteString(e.pw, ansi.Blur)
+			_, _ = io.WriteString(e.replies, ansi.Blur)
 		}
 	}
 }

--- a/vt/handlers.go
+++ b/vt/handlers.go
@@ -1,8 +1,6 @@
 package vt
 
 import (
-	"io"
-
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -692,7 +690,7 @@ func (e *Emulator) registerDefaultCsiHandlers() {
 		}
 
 		// Do we fully support VT220?
-		_, _ = io.WriteString(e.pw, ansi.PrimaryDeviceAttributes(
+		_, _ = writeReplyString(e.replies, ansi.PrimaryDeviceAttributes(
 			62, // VT220
 			1,  // 132 columns
 			6,  // Selective Erase
@@ -709,7 +707,7 @@ func (e *Emulator) registerDefaultCsiHandlers() {
 		}
 
 		// Do we fully support VT220?
-		_, _ = io.WriteString(e.pw, ansi.SecondaryDeviceAttributes(
+		_, _ = writeReplyString(e.replies, ansi.SecondaryDeviceAttributes(
 			1,  // VT220
 			10, // Version 1.0
 			0,  // ROM Cartridge is always zero
@@ -803,10 +801,10 @@ func (e *Emulator) registerDefaultCsiHandlers() {
 		case 5: // Operating Status
 			// We're always ready ;)
 			// See: https://vt100.net/docs/vt510-rm/DSR-OS.html
-			_, _ = io.WriteString(e.pw, ansi.DeviceStatusReport(ansi.DECStatusReport(0)))
+			_, _ = writeReplyString(e.replies, ansi.DeviceStatusReport(ansi.DECStatusReport(0)))
 		case 6: // Cursor Position Report [ansi.CPR]
 			x, y := e.scr.CursorPosition()
-			_, _ = io.WriteString(e.pw, ansi.CursorPositionReport(y+1, x+1))
+			_, _ = writeReplyString(e.replies, ansi.CursorPositionReport(y+1, x+1))
 		default:
 			return false
 		}
@@ -823,7 +821,7 @@ func (e *Emulator) registerDefaultCsiHandlers() {
 		switch n {
 		case 6: // Extended Cursor Position Report [ansi.DECXCPR]
 			x, y := e.scr.CursorPosition()
-			_, _ = io.WriteString(e.pw, ansi.ExtendedCursorPositionReport(y+1, x+1, 0)) // We don't support page numbers //nolint:errcheck
+			_, _ = writeReplyString(e.replies, ansi.ExtendedCursorPositionReport(y+1, x+1, 0)) // We don't support page numbers //nolint:errcheck
 		default:
 			return false
 		}

--- a/vt/key.go
+++ b/vt/key.go
@@ -297,7 +297,7 @@ func (e *Emulator) SendKey(k uv.KeyEvent) {
 			}
 		}
 
-		io.WriteString(e.pw, seq) //nolint:errcheck,gosec
+		io.WriteString(e.replies, seq) //nolint:errcheck,gosec
 	}
 }
 

--- a/vt/mouse.go
+++ b/vt/mouse.go
@@ -108,8 +108,8 @@ func (e *Emulator) SendMouse(m Mouse) {
 	// XXX: Support [ansi.Utf8ExtMouseMode], [ansi.UrxvtExtMouseMode], and
 	// [ansi.SgrPixelExtMouseMode].
 	case nil: // X10 mouse encoding
-		_, _ = io.WriteString(e.pw, ansi.MouseX10(b, mouse.X, mouse.Y))
+		_, _ = io.WriteString(e.replies, ansi.MouseX10(b, mouse.X, mouse.Y))
 	case ansi.ModeMouseExtSgr: // SGR mouse encoding
-		_, _ = io.WriteString(e.pw, ansi.MouseSgr(b, mouse.X, mouse.Y, isRelease))
+		_, _ = io.WriteString(e.replies, ansi.MouseSgr(b, mouse.X, mouse.Y, isRelease))
 	}
 }

--- a/vt/osc.go
+++ b/vt/osc.go
@@ -5,7 +5,6 @@ package vt
 import (
 	"bytes"
 	"image/color"
-	"io"
 
 	"github.com/charmbracelet/x/ansi"
 )
@@ -84,17 +83,17 @@ func (e *Emulator) handleDefaultColor(cmd int, data []byte) {
 			case 10: // Query foreground color
 				xrgb.Color = e.ForegroundColor()
 				if xrgb.Color != nil {
-					io.WriteString(e.pw, ansi.SetForegroundColor(xrgb.String())) //nolint:errcheck,gosec
+					writeReplyString(e.replies, ansi.SetForegroundColor(xrgb.String())) //nolint:errcheck,gosec
 				}
 			case 11: // Query background color
 				xrgb.Color = e.BackgroundColor()
 				if xrgb.Color != nil {
-					io.WriteString(e.pw, ansi.SetBackgroundColor(xrgb.String())) //nolint:errcheck,gosec
+					writeReplyString(e.replies, ansi.SetBackgroundColor(xrgb.String())) //nolint:errcheck,gosec
 				}
 			case 12: // Query cursor color
 				xrgb.Color = e.CursorColor()
 				if xrgb.Color != nil {
-					io.WriteString(e.pw, ansi.SetCursorColor(xrgb.String())) //nolint:errcheck,gosec
+					writeReplyString(e.replies, ansi.SetCursorColor(xrgb.String())) //nolint:errcheck,gosec
 				}
 			}
 		} else if c := ansi.XParseColor(arg); c != nil {

--- a/vt/reply.go
+++ b/vt/reply.go
@@ -1,0 +1,171 @@
+package vt
+
+import (
+	"io"
+	"sync"
+)
+
+// maxReplyBytes bounds how much unread *reply* traffic the emulator keeps. A
+// consumer that never reads is the normal case for a passive screen model, and
+// the traffic that provokes replies — status, device attribute and colour
+// queries — is unbounded, so something has to give. Input the consumer sends
+// itself is never dropped; see [replyBuffer.Write].
+const maxReplyBytes = 64 << 10
+
+// outgoing is one queued write: a complete escape sequence or a run of text.
+type outgoing struct {
+	data []byte
+	// reply marks traffic the emulator generated in answer to a query, which
+	// may be dropped under pressure. Everything the consumer sent — keys,
+	// mouse reports, pastes — is kept whatever happens.
+	reply bool
+	// read marks a chunk the consumer has already started reading, which must
+	// not be dropped: doing so would splice the middle out of a sequence the
+	// consumer is part-way through parsing.
+	read bool
+}
+
+// replyBuffer carries what the emulator sends to whatever drives it: answers to
+// queries such as DSR and DA, and the input a consumer injects through
+// [Emulator.InputPipe], [Emulator.Paste] and the key and mouse helpers.
+//
+// It holds that traffic rather than handing it to an [io.Pipe], because a pipe
+// write parks until somebody reads. Ordinary terminal startup traffic asks the
+// terminal about itself, so [Emulator.Write] would block forever unless the
+// consumer happened to be draining replies concurrently — a requirement that
+// was easy to miss and turned normal output into a deadlock.
+//
+// Writes therefore never block. When the buffer is full, queued replies are
+// dropped oldest-first: a stale answer is worth less than a fresh one, and a
+// consumer that starts reading late wants the terminal's current state. Queued
+// writes are whole, so dropping loses complete sequences rather than slicing
+// one in half.
+type replyBuffer struct {
+	more  *sync.Cond
+	queue []outgoing
+	mu    sync.Mutex
+	// replyBytes counts only the droppable chunks, since those are what the
+	// bound governs. Counting consumer input here too would mean a paste
+	// larger than the bound left the buffer permanently over it, and every
+	// reply after that would be dropped on arrival.
+	replyBytes int
+	closed     bool
+}
+
+func newReplyBuffer() *replyBuffer {
+	b := &replyBuffer{}
+	b.more = sync.NewCond(&b.mu)
+	return b
+}
+
+// Write queues input from the consumer. It never blocks and is never dropped,
+// since the consumer chose to send it and knows how much it sent.
+func (b *replyBuffer) Write(p []byte) (int, error) {
+	return b.write(p, false)
+}
+
+// writeReply queues traffic the emulator generated in answer to a query. It
+// never blocks, and may be dropped if the consumer is not reading.
+func (b *replyBuffer) writeReply(p []byte) (int, error) {
+	return b.write(p, true)
+}
+
+func (b *replyBuffer) write(p []byte, reply bool) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return 0, io.ErrClosedPipe
+	}
+
+	// The caller may reuse p.
+	chunk := make([]byte, len(p))
+	copy(chunk, p)
+
+	b.queue = append(b.queue, outgoing{data: chunk, reply: reply})
+	if reply {
+		b.replyBytes += len(chunk)
+		b.evict()
+	}
+	b.more.Signal()
+
+	return len(p), nil
+}
+
+// evict drops queued replies, oldest first, until the buffer is back within its
+// bound. It skips consumer input and any chunk already part-read, so what
+// survives is always a sequence of whole, in-order writes. The newest chunk is
+// kept even when it alone exceeds the bound, since dropping it would mean a
+// large but perfectly good answer never arrives.
+func (b *replyBuffer) evict() {
+	for i := 0; b.replyBytes > maxReplyBytes && i < len(b.queue)-1; {
+		if !b.queue[i].reply || b.queue[i].read {
+			i++
+			continue
+		}
+
+		b.replyBytes -= len(b.queue[i].data)
+		if i == 0 {
+			// The common case: reslicing beats memmoving the whole queue on
+			// every write once the buffer is full.
+			b.queue = b.queue[1:]
+			continue
+		}
+		b.queue = append(b.queue[:i], b.queue[i+1:]...)
+	}
+}
+
+// Read returns queued traffic, blocking until some arrives or the buffer is
+// closed. What is already queued is still delivered after a close; [io.EOF]
+// follows once it runs out.
+func (b *replyBuffer) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for len(b.queue) == 0 && !b.closed {
+		b.more.Wait()
+	}
+
+	if len(b.queue) == 0 {
+		return 0, io.EOF
+	}
+
+	head := &b.queue[0]
+	n := copy(p, head.data)
+	if head.reply {
+		b.replyBytes -= n
+	}
+
+	if n == len(head.data) {
+		b.queue = b.queue[1:]
+	} else {
+		head.data = head.data[n:]
+		head.read = true
+	}
+
+	return n, nil
+}
+
+// Close stops further writes and wakes every waiting reader.
+func (b *replyBuffer) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.closed = true
+	b.more.Broadcast()
+
+	return nil
+}
+
+// writeReplyString is [io.WriteString] for the droppable reply path.
+func writeReplyString(b *replyBuffer, s string) (int, error) {
+	return b.writeReply([]byte(s))
+}

--- a/vt/reply_test.go
+++ b/vt/reply_test.go
@@ -1,0 +1,398 @@
+package vt
+
+import (
+	"io"
+
+	"github.com/charmbracelet/x/ansi"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestWriteDoesNotBlockOnReplies is the case from the issue: feeding the
+// emulator a query with nobody draining its replies must not wedge the writer.
+func TestWriteDoesNotBlockOnReplies(t *testing.T) {
+	t.Parallel()
+
+	term := newTestTerminal(t, 80, 24)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		term.Write([]byte("\x1b[5n")) //nolint:errcheck // writing to an emulator cannot fail
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Write blocked waiting for its reply to be read")
+	}
+}
+
+// TestRepliesSurviveUntilRead checks the replies are still there afterwards:
+// not blocking must not mean discarding.
+func TestRepliesSurviveUntilRead(t *testing.T) {
+	t.Parallel()
+
+	term := newTestTerminal(t, 80, 24)
+	term.Write([]byte("\x1b[5n")) //nolint:errcheck // writing to an emulator cannot fail
+
+	buf := make([]byte, 64)
+	n, err := term.Read(buf)
+	if err != nil {
+		t.Fatalf("reading the reply: %v", err)
+	}
+	if got, want := string(buf[:n]), "\x1b[?0n"; got != want {
+		t.Errorf("reply: got %q, want %q", got, want)
+	}
+}
+
+// TestRepliesAreBounded checks an unread emulator cannot grow without limit. A
+// screen model that never reads is the normal case, and traffic asking the
+// terminal about itself is unbounded.
+func TestRepliesAreBounded(t *testing.T) {
+	t.Parallel()
+
+	term := newTestTerminal(t, 80, 24)
+	for range 20000 {
+		term.Write([]byte("\x1b[5n")) //nolint:errcheck // writing to an emulator cannot fail
+	}
+
+	// Close the buffer so draining terminates, then count what survived.
+	if err := term.replies.Close(); err != nil {
+		t.Fatalf("closing the reply buffer: %v", err)
+	}
+
+	var drained []byte
+	buf := make([]byte, 4096)
+	for {
+		n, err := term.replies.Read(buf)
+		drained = append(drained, buf[:n]...)
+		if err != nil {
+			break
+		}
+	}
+
+	if len(drained) > maxReplyBytes {
+		t.Errorf("kept %d bytes of replies, want at most %d", len(drained), maxReplyBytes)
+	}
+	if len(drained) == 0 {
+		t.Error("dropped every reply, want the most recent ones kept")
+	}
+
+	// What survives has to be whole replies in order, not a sequence sliced in
+	// half. Compared against an exact repetition, since TrimLeft takes a cutset
+	// and would accept any scramble of those bytes.
+	const reply = "\x1b[?0n"
+	if want := strings.Repeat(reply, len(drained)/len(reply)); string(drained) != want {
+		t.Errorf("drained replies are not whole: got %q", drained)
+	}
+	if len(drained)%len(reply) != 0 {
+		t.Errorf("drained %d bytes, not a whole number of %d-byte replies", len(drained), len(reply))
+	}
+}
+
+// TestReadBlocksUntilAReplyArrives keeps the reader side of the contract: a
+// consumer draining the emulator waits rather than spinning on empty reads.
+func TestReadBlocksUntilAReplyArrives(t *testing.T) {
+	t.Parallel()
+
+	term := newTestTerminal(t, 80, 24)
+
+	got := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, err := term.Read(buf)
+		if err != nil {
+			got <- "error: " + err.Error()
+			return
+		}
+		got <- string(buf[:n])
+	}()
+
+	select {
+	case reply := <-got:
+		t.Fatalf("Read returned %q before anything was written", reply)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	term.Write([]byte("\x1b[5n")) //nolint:errcheck // writing to an emulator cannot fail
+
+	select {
+	case reply := <-got:
+		if want := "\x1b[?0n"; reply != want {
+			t.Errorf("reply: got %q, want %q", reply, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read did not wake up when a reply arrived")
+	}
+}
+
+// TestReadAfterCloseReturnsEOF preserves what closing meant with the pipe: a
+// closed emulator reads as EOF. The buffer itself will drain what it holds, but
+// [Emulator.Read] short-circuits on close, and that is existing behaviour this
+// change deliberately leaves alone.
+func TestReadAfterCloseReturnsEOF(t *testing.T) {
+	t.Parallel()
+
+	term := newTestTerminal(t, 80, 24)
+	term.Write([]byte("\x1b[5n")) //nolint:errcheck // writing to an emulator cannot fail
+	if err := term.Close(); err != nil {
+		t.Fatalf("closing: %v", err)
+	}
+
+	buf := make([]byte, 64)
+	if _, err := term.Read(buf); err != io.EOF { //nolint:errorlint // io.EOF is compared by identity
+		t.Errorf("reading a closed emulator: got %v, want io.EOF", err)
+	}
+}
+
+// TestReplyBufferDrainsAfterClose covers the buffer's own contract: a close
+// wakes readers and hands over what is already queued before reporting EOF, so
+// a consumer draining concurrently does not lose the last reply.
+func TestReplyBufferDrainsAfterClose(t *testing.T) {
+	t.Parallel()
+
+	b := newReplyBuffer()
+	if _, err := b.Write([]byte("\x1b[?0n")); err != nil {
+		t.Fatalf("queueing a reply: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("closing: %v", err)
+	}
+
+	buf := make([]byte, 64)
+	n, err := b.Read(buf)
+	if err != nil {
+		t.Fatalf("draining after close: %v", err)
+	}
+	if got, want := string(buf[:n]), "\x1b[?0n"; got != want {
+		t.Errorf("drained reply: got %q, want %q", got, want)
+	}
+
+	if _, err := b.Read(buf); err != io.EOF { //nolint:errorlint // io.EOF is compared by identity
+		t.Errorf("reading an empty closed buffer: got %v, want io.EOF", err)
+	}
+
+	if _, err := b.Write([]byte("late")); err != io.ErrClosedPipe { //nolint:errorlint // sentinel compared by identity
+		t.Errorf("writing to a closed buffer: got %v, want io.ErrClosedPipe", err)
+	}
+}
+
+// TestRepliesUnderConcurrentReaderAndWriter exercises the lock: a consumer
+// draining while queries keep arriving is the shape this buffer exists for, and
+// it is the shape a data race would show up in.
+func TestRepliesUnderConcurrentReaderAndWriter(t *testing.T) {
+	t.Parallel()
+
+	b := newReplyBuffer()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 16)
+		for {
+			if _, err := b.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	for range 5000 {
+		if _, err := b.Write([]byte("\x1b[?0n")); err != nil {
+			t.Errorf("queueing a reply: %v", err)
+			break
+		}
+	}
+
+	if err := b.Close(); err != nil {
+		t.Fatalf("closing: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reader did not wake on close")
+	}
+}
+
+// TestPasteSurvivesReplyPressure checks that what the consumer sends is never
+// what gets dropped. A paste larger than the reply bound is still consumer
+// input: discarding it would lose the pasted text and leave the application
+// with a bracketed-paste end and no start.
+func TestPasteSurvivesReplyPressure(t *testing.T) {
+	t.Parallel()
+
+	term := newTestTerminal(t, 80, 24)
+	term.Write([]byte("\x1b[?2004h")) //nolint:errcheck // writing to an emulator cannot fail
+
+	text := strings.Repeat("x", maxReplyBytes+4096)
+	term.Paste(text)
+
+	if err := term.replies.Close(); err != nil {
+		t.Fatalf("closing the reply buffer: %v", err)
+	}
+
+	var drained []byte
+	buf := make([]byte, 8192)
+	for {
+		n, err := term.replies.Read(buf)
+		drained = append(drained, buf[:n]...)
+		if err != nil {
+			break
+		}
+	}
+
+	want := ansi.BracketedPasteStart + text + ansi.BracketedPasteEnd
+	if string(drained) != want {
+		t.Errorf("paste of %d bytes drained as %d bytes; consumer input must not be dropped",
+			len(text), len(drained))
+	}
+}
+
+// TestPartiallyReadReplyIsNotEvicted covers the other way a stream can be
+// spliced: dropping the remainder of a chunk the consumer is part-way through
+// reading would hand it the front of one sequence and the back of another.
+func TestPartiallyReadReplyIsNotEvicted(t *testing.T) {
+	t.Parallel()
+
+	b := newReplyBuffer()
+
+	const reply = "\x1b[?0n"
+	if _, err := b.writeReply([]byte(reply)); err != nil {
+		t.Fatalf("queueing a reply: %v", err)
+	}
+
+	// Read two bytes, leaving the rest of that reply queued.
+	head := make([]byte, 2)
+	if _, err := b.Read(head); err != nil {
+		t.Fatalf("reading the head of a reply: %v", err)
+	}
+
+	// Now push the buffer well past its bound.
+	for range 20000 {
+		if _, err := b.writeReply([]byte(reply)); err != nil {
+			t.Fatalf("queueing a reply: %v", err)
+		}
+	}
+
+	if err := b.Close(); err != nil {
+		t.Fatalf("closing: %v", err)
+	}
+
+	rest := make([]byte, len(reply))
+	n, err := b.Read(rest)
+	if err != nil {
+		t.Fatalf("reading the rest of the part-read reply: %v", err)
+	}
+	if got, want := string(rest[:n]), reply[2:]; got != want {
+		t.Errorf("part-read reply resumed as %q, want %q", got, want)
+	}
+}
+
+// TestCloseUnblocksAConcurrentReader is the shape that makes the closed flag
+// worth synchronising: one goroutine parked in Read, another closing. Under
+// -race this is where an unsynchronised flag shows up.
+func TestCloseUnblocksAConcurrentReader(t *testing.T) {
+	t.Parallel()
+
+	term := newTestTerminal(t, 80, 24)
+
+	done := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 64)
+		_, err := term.Read(buf)
+		done <- err
+	}()
+
+	// Give the reader time to park.
+	time.Sleep(50 * time.Millisecond)
+
+	if err := term.Close(); err != nil {
+		t.Fatalf("closing: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != io.EOF { //nolint:errorlint // io.EOF is compared by identity
+			t.Errorf("parked reader woke with %v, want io.EOF", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not wake the parked reader")
+	}
+}
+
+// drainReplies closes the emulator's reply buffer and returns everything it
+// held, so a test can assert on replies without a concurrent reader.
+func drainReplies(t *testing.T, term *Emulator) string {
+	t.Helper()
+
+	if err := term.replies.Close(); err != nil {
+		t.Fatalf("closing the reply buffer: %v", err)
+	}
+
+	var drained []byte
+	buf := make([]byte, 8192)
+	for {
+		n, err := term.replies.Read(buf)
+		drained = append(drained, buf[:n]...)
+		if err != nil {
+			break
+		}
+	}
+
+	return string(drained)
+}
+
+// TestQueriesAnsweredAfterABigPaste checks that consumer input, which is never
+// dropped, cannot starve the replies. If the bound counted that input, a paste
+// larger than the bound would leave the buffer permanently over it and answers
+// arriving afterwards would be dropped — an application waiting on its
+// device-attributes answer would hang.
+func TestQueriesAnsweredAfterABigPaste(t *testing.T) {
+	t.Parallel()
+
+	// What the answers look like with nothing else going on.
+	quiet := newTestTerminal(t, 80, 24)
+	quiet.Write([]byte("\x1b[c"))  //nolint:errcheck // primary device attributes
+	quiet.Write([]byte("\x1b[5n")) //nolint:errcheck // device status report
+	answers := drainReplies(t, quiet)
+	da, dsr, ok := strings.Cut(answers, "\x1b[?0n")
+	if !ok || da == "" {
+		t.Fatalf("could not tell the two answers apart in %q", answers)
+	}
+	dsr = "\x1b[?0n"
+
+	term := newTestTerminal(t, 80, 24)
+	term.Paste(strings.Repeat("x", maxReplyBytes+1))
+	term.Write([]byte("\x1b[c"))  //nolint:errcheck // writing to an emulator cannot fail
+	term.Write([]byte("\x1b[5n")) //nolint:errcheck // writing to an emulator cannot fail
+
+	drained := drainReplies(t, term)
+	if !strings.Contains(drained, da) {
+		t.Errorf("device attributes answer %q was dropped after a large paste", da)
+	}
+	if !strings.Contains(drained, dsr) {
+		t.Errorf("status answer %q was dropped after a large paste", dsr)
+	}
+}
+
+// TestResizeNotificationSurvivesReplyPressure keeps the one reply that is not
+// re-derivable. A stale status answer is worth dropping; a size the child never
+// learns leaves it rendering to the wrong dimensions forever.
+func TestResizeNotificationSurvivesReplyPressure(t *testing.T) {
+	t.Parallel()
+
+	term := newTestTerminal(t, 80, 24)
+	term.Write([]byte("\x1b[?2048h")) //nolint:errcheck // ask for in-band resize notifications
+	term.Resize(100, 30)
+
+	for range 20000 {
+		term.Write([]byte("\x1b[5n")) //nolint:errcheck // pile on droppable replies
+	}
+
+	drained := drainReplies(t, term)
+	if want := ansi.InBandResize(30, 100, 0, 0); !strings.Contains(drained, want) {
+		t.Errorf("resize notification %q was dropped under reply pressure", want)
+	}
+}


### PR DESCRIPTION
Fixes #939.

The emulator answered queries by writing into an `io.Pipe`, and a pipe write parks until somebody reads. Ordinary startup traffic asks the terminal about itself, so feeding that to a passive screen model wedged the writer — the issue's repro, verbatim:

```go
emu := vt.NewEmulator(80, 24)
emu.Write([]byte("\x1b[5n")) // never returns
```

A consumer could avoid it by draining the emulator continuously, but nothing said so, and missing that turned normal output into a deadlock rather than a dropped reply. (I hit this myself writing a test for an unrelated PR — the test deadlocked until I added a reader goroutine.)

## Shape

The issue left the shape open and listed three directions; this is the third, "a bounded non-blocking reply path", because it needs no API change and existing drain loops keep working.

Replies go into a bounded buffer that never blocks a write. Two distinctions turned out to matter, both found while testing this:

- **Consumer input is never dropped.** Keys, mouse reports and pastes are traffic the consumer chose to send and knows the size of. Only query answers are droppable — that traffic is unbounded and a consumer that never reads is the normal case. Without the split, a paste larger than the bound was discarded outright and the application got a bracketed-paste *end* with no start.
- **The bound counts only droppable bytes.** Otherwise a paste larger than the bound leaves the buffer permanently over it, and every answer arriving afterwards is dropped on arrival — an application waiting on its device-attributes answer would hang, which is the same failure this PR is meant to remove.

Under pressure the oldest replies go first, so a late reader gets the terminal's current state rather than its oldest. Writes are queued whole, so dropping loses complete sequences instead of splicing one in half, and a chunk a reader is part-way through is never dropped out from under it.

The in-band resize notification stays on the never-dropped path: unlike a stale status answer, a size the child never learns is not something it can re-derive.

`closed` becomes an `atomic.Bool`, since closing is now the only way to wake a reader parked in `Read` — it is read on one goroutine while another closes.

## Not changed

`Emulator.Read` still short-circuits to `io.EOF` once closed, as it did with the pipe. The buffer itself will hand over what it already holds before reporting EOF, so a consumer draining concurrently does not lose the last reply, but the emulator-level behaviour is left alone.

## Tests

The reported case; replies surviving until read; the bound holding; whole-sequence eviction; a part-read reply resuming intact; a paste larger than the bound arriving whole; answers still arriving after such a paste; the resize notification surviving pressure; `Read` blocking until a reply arrives; `Close` waking a parked reader; and a concurrent reader/writer pair under the race detector.

Every one was checked against a deliberately broken version to confirm it fails for the right reason. That is how the paste-loss, the starvation and the spliced-sequence cases were found in the first place — the first version of this change had all three, and the first version of the "replies stay whole" assertion was vacuous (`strings.TrimLeft` takes a cutset, not a prefix, so it accepted any scramble).

`go test -race -count=3 -shuffle=on` passes in `vt/`, `vttest` still builds, and `golangci-lint run --config ../.golangci.yml ./...` reports only the two findings already on `main` (`emulator.go:422`, `csi.go:38`), in files this PR does not touch.
