### PR TITLE
fix(vt): clamp scroll margins to screen bounds

### DIFF
--- a/vt/emulator_test.go
+++ b/vt/emulator_test.go
@@ -932,6 +932,22 @@ var cases = []struct {
 		},
 		pos: uv.Pos(3, 2),
 	},
+	{
+		name: "DECSTBM Bottom Beyond Screen",
+		w:    8, h: 4,
+		input: []string{
+			"\x1b[1;5r", // invalid bottom margin
+			"\x1bM",     // reverse index
+			"X",
+		},
+		want: []string{
+			"X       ",
+			"        ",
+			"        ",
+			"        ",
+		},
+		pos: uv.Pos(1, 0),
+	},
 
 	// Set Left/Right Margins [ansi.DECSLRM]
 	{
@@ -1017,6 +1033,22 @@ var cases = []struct {
 			"GHI     ",
 		},
 		pos: uv.Pos(3, 2),
+	},
+	{
+		name: "DECSLRM Right Beyond Screen",
+		w:    8, h: 3,
+		input: []string{
+			"\x1b[?69h", // enable left/right margins
+			"\x1b[1;9s", // invalid right margin
+			"\x1bM",     // reverse index
+			"X",
+		},
+		want: []string{
+			"X       ",
+			"        ",
+			"        ",
+		},
+		pos: uv.Pos(1, 0),
 	},
 
 	// Erase Character [ansi.ECH]

--- a/vt/handlers.go
+++ b/vt/handlers.go
@@ -870,10 +870,10 @@ func (e *Emulator) registerDefaultCsiHandlers() {
 		if bottom < 1 {
 			bottom = height
 		}
-
-		if top >= bottom {
+		if top >= bottom || top > height {
 			return false
 		}
+		bottom = min(bottom, height)
 
 		// Rect is [x, y) which means y is exclusive. So the top margin
 		// is the top of the screen minus one.
@@ -903,10 +903,10 @@ func (e *Emulator) registerDefaultCsiHandlers() {
 			if right < 1 {
 				right = width
 			}
-
-			if left >= right {
+			if left >= right || left > width {
 				return false
 			}
+			right = min(right, width)
 
 			e.scr.setHorizontalMargins(left-1, right)
 


### PR DESCRIPTION
Out-of-range DECSTBM and DECSLRM trailing margins were stored beyond the render buffer. A later reverse-index (`ESC M`) passed that rectangle to ultraviolet and panicked while indexing the first cell outside the grid.

Clamp bottom and right margins to the current screen dimensions, while preserving the existing handling of one-cell regions at the lower/right edge. Reject leading margins that begin beyond the screen.

This was observed in a live terminal resize and reduces to:

```go
term := vt.NewEmulator(30, 4)
term.Write([]byte("\x1b[?69h\x1b[1;31s\x1b[H\x1bM"))
```

Tests cover both DECSTBM and DECSLRM bounds.

Tested with `go test ./...` from `vt/`.

Downstream report: https://github.com/trentkm/stormlight/issues/199