### PR TITLE
fix(vt): bound margins and repeat counts to the screen

### DIFF
--- a/vt/csi_cursor.go
+++ b/vt/csi_cursor.go
@@ -12,7 +12,10 @@ func (e *Emulator) nextTab(n int) {
 	scroll := e.scr.ScrollRegion()
 	for range n {
 		ts := e.tabstops.Next(x)
-		if ts < x {
+		// Stop as soon as the cursor does not move: past the last tab stop the
+		// position stops changing, and without this the loop keeps going for
+		// however many repeats the sequence asked for.
+		if ts <= x {
 			break
 		}
 		x = ts
@@ -41,7 +44,9 @@ func (e *Emulator) prevTab(n int) {
 
 	for range n {
 		ts := e.tabstops.Prev(x)
-		if ts > x {
+		// As in [Emulator.nextTab]: no movement means there is nothing left to
+		// count down, whatever the sequence asked for.
+		if ts >= x {
 			break
 		}
 		x = ts
@@ -103,6 +108,15 @@ func (e *Emulator) carriageReturn() {
 func (e *Emulator) repeatPreviousCharacter(n int) {
 	if e.lastChar == 0 {
 		return
+	}
+	// A repeat count is a number from the sequence and can name far more
+	// characters than the screen could ever show, so it is capped rather than
+	// spent. Past a full screen the result repeats every [Emulator.Width]
+	// characters — the same cells, the cursor back in the same column, one
+	// more identical line of scrollback — so keeping that remainder leaves the
+	// screen and the cursor exactly where the whole count would have.
+	if w, area := e.Width(), e.Width()*e.Height(); w > 0 && n > area {
+		n = area + n%w
 	}
 	for range n {
 		e.handlePrint(e.lastChar)

--- a/vt/csi_screen.go
+++ b/vt/csi_screen.go
@@ -11,6 +11,11 @@ func (e *Emulator) eraseCharacter(n int) {
 		n = 1
 	}
 	x, y := e.scr.CursorPosition()
+	// The count comes from the sequence and may reach well past the line; the
+	// area is walked cell by cell, so erasing stops at the right edge.
+	if rest := e.scr.Width() - x; n > rest {
+		n = rest
+	}
 	rect := uv.Rect(x, y, n, 1)
 	e.scr.FillArea(e.scr.blankCell(), rect)
 	e.atPhantom = false

--- a/vt/margins_test.go
+++ b/vt/margins_test.go
@@ -1,0 +1,193 @@
+package vt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMarginsOutsideThePage covers margins set past the edge of the screen.
+// DECSTBM and DECSLRM take their bounds straight from the sequence, and a
+// program emitting one larger than the page used to leave a scroll region
+// pointing outside the buffer; the next scroll or line insertion then indexed
+// off the end and took the host process down with it. The bytes come from
+// whatever is running in the terminal, so this has to be survivable.
+func TestMarginsOutsideThePage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		width, height int
+		input         string
+	}{
+		{
+			name:  "DECSTBM bottom past the last row, then scroll up",
+			width: 4, height: 2, input: "\x1b[1;9r\x1b[S",
+		},
+		{
+			name:  "DECSTBM bottom past the last row, then scroll down",
+			width: 4, height: 2, input: "\x1b[1;9r\x1b[T",
+		},
+		{
+			name:  "DECSTBM top past the last row",
+			width: 4, height: 2, input: "\x1b[8;9r\x1b[S",
+		},
+		{
+			name:  "DECSLRM right past the last column, then scroll",
+			width: 2, height: 3, input: "\x1b[?69h\x1b[2;4s\x1b[S",
+		},
+		{
+			name:  "DECSLRM right past the last column, then insert line",
+			width: 2, height: 3, input: "\x1b[?69h\x1b[1;5s\x1b[L",
+		},
+		{
+			name:  "DECSLRM right past the last column, then delete line",
+			width: 2, height: 3, input: "\x1b[?69h\x1b[1;5s\x1b[M",
+		},
+		{
+			name:  "DECSLRM left past the last column",
+			width: 2, height: 3, input: "\x1b[?69h\x1b[7;9s\x1b[S",
+		},
+		{
+			name:  "DECSTBM entirely past the page",
+			width: 6, height: 3, input: "\x1b[9;10r\n\n\n\n",
+		},
+		{
+			name:  "DECSLRM entirely past the page, in origin mode",
+			width: 3, height: 3, input: "\x1b[?69h\x1b[?6h\x1b[7;9sabc",
+		},
+		{
+			name:  "both margins past the page, with text and a line feed",
+			width: 3, height: 2, input: "\x1b[?69h\x1b[1;9s\x1b[1;9rabc\ndef\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := NewEmulator(tc.width, tc.height)
+			// A panic here is the bug; the write must simply survive.
+			if _, err := e.Write([]byte(tc.input)); err != nil {
+				t.Fatalf("writing: %v", err)
+			}
+
+			// Whatever the sequence asked for, the scroll region has to stay
+			// inside the buffer or the next operation on it indexes off the
+			// end, and it has to keep at least one row and column: an empty
+			// region parked past the last line is in bounds but nothing can
+			// scroll within it, which garbles everything printed afterwards.
+			scroll := e.scr.scroll
+			if scroll.Min.X < 0 || scroll.Max.X > tc.width || scroll.Min.X >= scroll.Max.X {
+				t.Errorf("horizontal scroll region [%d,%d) is not a region inside a %d-column screen",
+					scroll.Min.X, scroll.Max.X, tc.width)
+			}
+			if scroll.Min.Y < 0 || scroll.Max.Y > tc.height || scroll.Min.Y >= scroll.Max.Y {
+				t.Errorf("vertical scroll region [%d,%d) is not a region inside a %d-row screen",
+					scroll.Min.Y, scroll.Max.Y, tc.height)
+			}
+		})
+	}
+}
+
+// TestCountedSequencesAreBounded covers sequences that take a repeat or erase
+// count. The count comes from the byte stream, so it can name far more cells
+// than the screen has, and the work used to be proportional to the number
+// rather than to the screen: a handful of bytes could hold the emulator for
+// seconds, which for a program rendering someone else's output is enough to
+// wedge it.
+func TestCountedSequencesAreBounded(t *testing.T) {
+	t.Parallel()
+
+	// Large enough that spending the count is unmistakable next to the budget,
+	// while still parsing as a single parameter.
+	const huge = "888888889"
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "ECH erase character", input: "\x1b[" + huge + "X"},
+		{name: "REP repeat character", input: "a\x1b[" + huge + "b"},
+		{name: "CHT forward tabs", input: "\x1b[" + huge + "I"},
+		{name: "CBT backward tabs", input: "\x1b[" + huge + "Z"},
+		{name: "ICH insert characters", input: "\x1b[" + huge + "@"},
+		{name: "DCH delete characters", input: "\x1b[" + huge + "P"},
+		{name: "IL insert lines", input: "\x1b[" + huge + "L"},
+		{name: "DL delete lines", input: "\x1b[" + huge + "M"},
+		{name: "SU scroll up", input: "\x1b[" + huge + "S"},
+		{name: "SD scroll down", input: "\x1b[" + huge + "T"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := NewEmulator(4, 3)
+			// The error is read after the wait rather than reported from the
+			// goroutine: on timeout the subtest ends while the write is still
+			// running, and reporting from it then takes down the whole binary.
+			var writeErr error
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				_, writeErr = e.Write([]byte(tc.input))
+			}()
+
+			select {
+			case <-done:
+				if writeErr != nil {
+					t.Errorf("writing: %v", writeErr)
+				}
+			case <-time.After(500 * time.Millisecond):
+				// Still enormous headroom: every one of these takes
+				// microseconds once the work is bounded by the screen rather
+				// than by the count, and seconds when it is not.
+				t.Fatal("the sequence spent its count instead of stopping at the screen")
+			}
+		})
+	}
+}
+
+// TestRepeatCountMatchesTheWholeCount pins that capping REP is invisible. The
+// count is bounded so a huge one cannot be spent, but the screen and the cursor
+// have to end up where writing every repeat would have left them: past a full
+// screen the result repeats every Width characters, so keeping that remainder
+// is what makes the cap unobservable. Compared against actually writing the
+// characters, which is the behaviour REP stands in for.
+func TestRepeatCountMatchesTheWholeCount(t *testing.T) {
+	t.Parallel()
+
+	const width, height = 4, 3
+
+	// A count of zero is left out: this emulator repeats nothing for it,
+	// where ECMA-48 makes an omitted or zero parameter mean one. That is a
+	// separate question from bounding a large one.
+	for _, n := range []int{1, 3, 4, 11, 12, 13, 200, 1001} {
+		repeated := NewEmulator(width, height)
+		if _, err := repeated.Write([]byte(fmt.Sprintf("a\x1b[%db", n))); err != nil {
+			t.Fatalf("n=%d: writing the repeat: %v", n, err)
+		}
+
+		written := NewEmulator(width, height)
+		if _, err := written.Write([]byte(strings.Repeat("a", n+1))); err != nil {
+			t.Fatalf("n=%d: writing the characters: %v", n, err)
+		}
+
+		if got, want := repeated.CursorPosition(), written.CursorPosition(); got != want {
+			t.Errorf("n=%d: cursor = %v, want %v", n, got, want)
+		}
+		for y := range height {
+			for x := range width {
+				got, want := repeated.CellAt(x, y), written.CellAt(x, y)
+				if got == nil || want == nil {
+					continue
+				}
+				if got.Content != want.Content {
+					t.Errorf("n=%d: cell (%d,%d) = %q, want %q", n, x, y, got.Content, want.Content)
+				}
+			}
+		}
+	}
+}

--- a/vt/screen.go
+++ b/vt/screen.go
@@ -134,16 +134,24 @@ func (s *Screen) FillArea(c *uv.Cell, area uv.Rectangle) {
 	s.touchArea(area)
 }
 
-// setHorizontalMargins sets the horizontal margins.
+// setHorizontalMargins sets the horizontal margins, clamped to the screen.
+// [ansi.DECSLRM] takes its bounds from the sequence, so a program can name a
+// column the screen does not have. The region is indexed directly when
+// scrolling and when inserting or deleting lines, so it has to stay inside the
+// buffer, and it has to stay non-empty: a region of no columns is one nothing
+// can scroll within, which garbles every line that follows.
 func (s *Screen) setHorizontalMargins(left, right int) {
-	s.scroll.Min.X = left
-	s.scroll.Max.X = right
+	w := s.Width()
+	s.scroll.Min.X = ordered.Clamp(left, 0, max(w-1, 0))
+	s.scroll.Max.X = ordered.Clamp(right, s.scroll.Min.X+1, w)
 }
 
-// setVerticalMargins sets the vertical margins.
+// setVerticalMargins sets the vertical margins, clamped to the screen, for the
+// same reasons as [Screen.setHorizontalMargins].
 func (s *Screen) setVerticalMargins(top, bottom int) {
-	s.scroll.Min.Y = top
-	s.scroll.Max.Y = bottom
+	h := s.Height()
+	s.scroll.Min.Y = ordered.Clamp(top, 0, max(h-1, 0))
+	s.scroll.Max.Y = ordered.Clamp(bottom, s.scroll.Min.Y+1, h)
 }
 
 // setCursorX sets the cursor X position. If margins is true, the cursor is


### PR DESCRIPTION
Several sequences take a number straight from the byte stream and use it to index the buffer or to size a loop. The bytes are whatever the program in the terminal emits, so a few of them are enough to take the host process down or hold it still. On `main`:

```
\x1b[?69h\x1b[2;4s\x1b[S    on 2 columns -> panic: index out of range [2] with length 2
\x1b[1;9r\x1b[S             on 2 rows    -> panic: index out of range [2] with length 2
\x1b[1;9r\x1b[T             on 2 rows    -> panic: index out of range [7] with length 2
\x1b[?69h\x1b[1;5s\x1b[L    on 2 columns -> panic
\x1b[888888889X                          -> 1.5s
\x1b[888888889I  and  ...Z               -> 2.6s each
a\x1b[888888889b                         -> minutes
```

A program embedding `vt` to render another program's output — which is the point of it — can be crashed or wedged by a handful of bytes, including from a file someone else wrote.

I found these while working on #935; the panic was surfaced by a reviewer on that branch.

## The margins

`DECSTBM` and `DECSLRM` are clamped **where the region is stored** rather than where it is parsed. That keeps every sequence accepted or rejected exactly as before, while the region itself stays inside the buffer. Clamping at parse time instead breaks `TestTerminal/CUP_Relative_to_Origin`, which relies on `\x1b[2;3r` being accepted on a two-row screen.

The region is also kept at least one row and one column wide. An empty region parked past the last line is technically in bounds but nothing can scroll within it, and every line printed afterwards comes out wrong — `\x1b[9;10r` on a 6x3 screen produced exactly that.

## The counted sequences

- `ECH` stops at the right edge; it cannot erase a column the line does not have.
- The tab loops (`CHT`, `CBT`) stop as soon as the cursor does not move. Past the last tab stop the position stops changing and they were counting down the parameter regardless.
- `REP` is capped at a screenful **plus the remainder of the count over the width**. A plain screenful cap is observable — the cursor ends in the wrong column — because past a full screen the result repeats every `Width` characters. `TestRepeatCountMatchesTheWholeCount` checks the capped result against actually writing the characters.

## Not addressed

`CSI 0 b` repeats zero times where ECMA-48 makes an omitted or zero parameter mean one. Pre-existing, and a separate question from bounding a large one.

## Tests

`TestMarginsOutsideThePage` drives each panic sequence and then asserts the scroll region is a region *inside* the buffer — the weaker "not out of bounds" check passes on the empty-region case, so it checks both. `TestCountedSequencesAreBounded` gives each counted sequence a budget several orders of magnitude above what it needs once the work is bounded by the screen rather than the count.

`gofmt`, `go vet`, `golangci-lint --config ../.golangci.yml` (matches `main`'s two pre-existing findings), `go test ./... -race -count=3 -shuffle=on`, and 90s of fuzzing for further panics with no new findings.
