### PR TITLE
fix(vt): wrap a wide character by the columns it covers

### DIFF
--- a/vt/utf8.go
+++ b/vt/utf8.go
@@ -51,14 +51,6 @@ func (e *Emulator) handleGrapheme(content string, width int) {
 	}
 
 	x, y := e.scr.CursorPosition()
-	if e.atPhantom && awm {
-		// moves cursor down similar to [Terminal.linefeed] except it doesn't
-		// respects [ansi.LNM] mode.
-		// This will reset the phantom state i.e. pending wrap state.
-		e.index()
-		_, y = e.scr.CursorPosition()
-		x = 0
-	}
 
 	// Handle character set mappings
 	if len(content) == 1 { //nolint:nestif
@@ -85,11 +77,35 @@ func (e *Emulator) handleGrapheme(content string, width int) {
 		e.lastChar, _ = utf8.DecodeRuneInString(content)
 	}
 
+	// Wrap once the cell is final, since the character set mapping above may
+	// have changed its width. Either a wrap is already pending, or the cell is
+	// wider than the room left on the line — a two-column character with one
+	// column to go belongs on the next line whole, not written over the edge.
+	// A cell too wide for the screen itself is placed regardless; no line
+	// would hold it and looking for one would only lose it.
+	scrWidth := e.scr.Width()
+	if awm && (e.atPhantom || (x+cell.Width > scrWidth && cell.Width <= scrWidth)) {
+		// moves cursor down similar to [Terminal.linefeed] except it doesn't
+		// respects [ansi.LNM] mode.
+		// This will reset the phantom state i.e. pending wrap state.
+		e.index()
+		_, y = e.scr.CursorPosition()
+		x = 0
+	}
+
 	e.scr.SetCell(x, y, &cell)
 
-	// Handle phantom state at the end of the line
-	e.atPhantom = awm && x >= e.scr.Width()-1
-	if !e.atPhantom {
+	// Handle phantom state at the end of the line. The cell occupies the
+	// columns from x to x+Width, so it is the far edge of a wide one that
+	// decides whether the line is full, not the column it starts in.
+	e.atPhantom = awm && x+cell.Width >= scrWidth
+	if e.atPhantom {
+		// Pending wrap leaves the cursor on the cell, and for a wide one that
+		// is its last column, not its first: everything that reads the cursor
+		// back — a resize, a backspace, a cursor report — expects the column
+		// the character reached.
+		x += cell.Width - 1
+	} else {
 		x += cell.Width
 	}
 

--- a/vt/widechar_test.go
+++ b/vt/widechar_test.go
@@ -1,0 +1,143 @@
+package vt
+
+import (
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// TestWideCharAtLineEnd covers a double-width character meeting the right edge.
+// The pending-wrap rule asks whether the cursor reached the last column, which
+// is the right question only for a character one column wide: a two-column one
+// ending exactly at the edge left the cursor sitting on its second half, so the
+// next character overwrote it, and one with a single column left was written
+// past the edge and lost instead of moving to the next line.
+func TestWideCharAtLineEnd(t *testing.T) {
+	t.Parallel()
+
+	const thumbsUp = "\U0001F44D" // two columns
+
+	tests := []struct {
+		name  string
+		input string
+		// want is the screen as rows of cell contents; "" is the blank that
+		// trails a wide cell, " " an untouched cell.
+		want [][]string
+	}{
+		{
+			name:  "narrow character fills the line, next one wraps",
+			input: "abcd" + "e",
+			want:  [][]string{{"a", "b", "c", "d"}, {"e", " ", " ", " "}},
+		},
+		{
+			name:  "wide character ends at the last column, next one wraps",
+			input: "ab" + thumbsUp + "c",
+			want:  [][]string{{"a", "b", thumbsUp, ""}, {"c", " ", " ", " "}},
+		},
+		{
+			name:  "wide character does not fit, so it wraps whole",
+			input: "abc" + thumbsUp,
+			want:  [][]string{{"a", "b", "c", " "}, {thumbsUp, "", " ", " "}},
+		},
+		{
+			name:  "wide character does not fit, and text follows it",
+			input: "abc" + thumbsUp + "d",
+			want:  [][]string{{"a", "b", "c", " "}, {thumbsUp, "", "d", " "}},
+		},
+		{
+			name:  "two wide characters filling a line exactly",
+			input: thumbsUp + thumbsUp + "x",
+			want:  [][]string{{thumbsUp, "", thumbsUp, ""}, {"x", " ", " ", " "}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := NewEmulator(4, 2)
+			if _, err := e.Write([]byte(tc.input)); err != nil {
+				t.Fatalf("writing: %v", err)
+			}
+
+			for y, row := range tc.want {
+				for x, want := range row {
+					cell := e.CellAt(x, y)
+					if cell == nil {
+						t.Errorf("cell (%d,%d) is missing", x, y)
+						continue
+					}
+					if cell.Content != want {
+						t.Errorf("cell (%d,%d) = %q, want %q", x, y, cell.Content, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestWideCharOnANarrowScreen covers a character too wide for the screen at
+// all. No line could ever hold it, so the wrap must not go looking for one:
+// moving down first would spend a line before writing a character that will
+// not show either way. Nothing here can be displayed on one column; what is
+// being pinned is that the attempt costs nothing extra.
+func TestWideCharOnANarrowScreen(t *testing.T) {
+	t.Parallel()
+
+	e := NewEmulator(1, 3)
+	if _, err := e.Write([]byte("\U0001F44D")); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+
+	if got := e.CursorPosition(); got.Y != 0 {
+		t.Errorf("cursor = %v, want it still on the first row", got)
+	}
+	if n := e.ScrollbackLen(); n != 0 {
+		t.Errorf("scrollback grew to %d lines writing a single character", n)
+	}
+}
+
+// TestWideCharPendingWrapCursorColumn pins where the cursor is left when a wide
+// character fills the line. Pending wrap keeps the cursor on the character
+// rather than past it, and for a two-column one that has to be the column it
+// reached: everything that reads the cursor back afterwards — a backspace, a
+// cursor report, a resize — works from that column, and leaving it on the
+// character's first half puts them all one place out.
+func TestWideCharPendingWrapCursorColumn(t *testing.T) {
+	t.Parallel()
+
+	const thumbsUp = "\U0001F44D"
+
+	t.Run("cursor sits on the last column the character reached", func(t *testing.T) {
+		t.Parallel()
+
+		e := NewEmulator(4, 2)
+		if _, err := e.Write([]byte("ab" + thumbsUp)); err != nil {
+			t.Fatalf("writing: %v", err)
+		}
+		if got := e.CursorPosition().X; got != 3 {
+			t.Errorf("cursor x = %d, want 3 -- the emoji covers columns 2 and 3", got)
+		}
+	})
+
+	t.Run("backspace steps onto the character, not past it", func(t *testing.T) {
+		t.Parallel()
+
+		e := NewEmulator(4, 2)
+		if _, err := e.Write([]byte("ab" + thumbsUp + "\bX")); err != nil {
+			t.Fatalf("writing: %v", err)
+		}
+		// Backspace from the emoji's last column lands on the emoji, so X
+		// replaces it; "b" is not what is being backed over.
+		if c := e.CellAt(1, 0); c == nil || c.Content != "b" {
+			t.Errorf("cell 1 = %q, want %q -- the backspace went one column too far", cellAt(c), "b")
+		}
+	})
+}
+
+func cellAt(c *uv.Cell) string {
+	if c == nil {
+		return "<nil>"
+	}
+	return c.Content
+}


### PR DESCRIPTION
Pending wrap asked whether the cursor had reached the last column, which is the right question only for a character one column wide. A two-column one was handled as though it occupied the column it started in, and CJK and emoji were silently dropped at line ends as a result.

On `main`, rendering into a small screen:

```
3x3  "a中文b"   "a"," "," " | "b"            <- 中 and 文 both lost
5x2  "a中文b"   "a","中","", ,"b"            <- 文 lost
4x2  "ab👍c"    "a","b"," ","c"              <- emoji destroyed by the "c"
```

Two distinct failures:

- **Ending exactly at the right edge** left no wrap pending, so the next character was written over the second half of the wide one and destroyed it.
- **With a single column left**, the character was written past the edge and the screen dropped it, rather than moving to the next line.

## What changed

The wrap compares `x + cell.Width` against the screen, so a character that will not fit in what is left of the line goes to the next line whole, and a line counts as full once the far edge of the last character reaches the end.

The decision also moved below the character set mapping, which can change a cell's width and so has to run first.

A character wider than the screen itself is written where it is. No line could hold it, and moving down to look would only spend a line per character — a one-column terminal fed CJK would scroll for ever without displaying anything.

Pending wrap leaves the cursor on the character's **last** column rather than its first. Everything that reads the cursor back works from there: a backspace steps onto the character instead of over it, and a cursor report names the column it reached. (Leaving it on the first column also creates a state that could not previously occur, which `Resize` then mishandles.)

## Evidence

Rendering a corpus of ASCII, CJK and emoji across five screen sizes, before and after: **20 of 130 cases change, every one of them a wide character at a line end, and no case without one differs.** Every change recovers a character that was previously lost.

## Not addressed, unchanged from before

Wrapping measures against the screen width rather than a `DECSLRM` right margin, so text set to a narrower right margin still runs to the screen edge. Verified byte-identical on `main`.

Also worth knowing: a same-size `Resize` clears pending wrap. That is pre-existing and happens for narrow characters on `main` too, so this change makes wide ones behave consistently with them rather than introducing anything.

## Overlap with #955

Both touch `handleGrapheme` and will conflict textually. They are independent fixes and either can go first; I am happy to rebase whichever you take second, or to fold them together if you would rather review one change.

This also resolves the limitation noted under "Not addressed" in #955 — a cluster whose finished width does not fit the last column.

## Tests

`gofmt`, `go vet`, `golangci-lint --config ../.golangci.yml` (matches `main`'s two pre-existing findings), `go test ./... -race -count=3 -shuffle=on`.
