### PR TITLE
fix(powernap): omit workDoneToken when unset (LSP spec disallows null)

### DIFF
--- a/powernap/pkg/lsp/protocol/tsprotocol.go
+++ b/powernap/pkg/lsp/protocol/tsprotocol.go
@@ -5926,7 +5926,7 @@ type WorkDoneProgressOptions struct {
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#workDoneProgressParams
 type WorkDoneProgressParams struct {
 	// An optional token that a server can use to report work done progress.
-	WorkDoneToken ProgressToken `json:"workDoneToken,omitempty"`
+	WorkDoneToken *ProgressToken `json:"workDoneToken,omitempty"`
 }
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification#workDoneProgressReport


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

## What?
`powernap` currently sends `"workDoneToken": null` in JSON to LSP servers. This is not a documented behavior in the LSP spec.

This PR converts it from a struct value to a pointer, so that it is omitted while being JSON marshalled.

## Why?

(image from `crush`)
<img width="977" height="66" alt="image" src="https://github.com/user-attachments/assets/e76799a3-22d4-4bcc-80b2-440626b6468c" />

The error is:
```
InvalidParams: json: cannot unmarshal into Go lsproto.DocumentSymbolParams
  within "/workDoneToken": null value is not allowed for field "workDoneToken"
```

## Validation

Tested what `powernap` was outputting using this script:

<details><summary>Generated by GLM-5.2</summary>

```go
package main

import (
	"encoding/json"
	"fmt"
	"github.com/charmbracelet/x/powernap/pkg/lsp/protocol"
)

func main() {
	params := protocol.DocumentSymbolParams{
		TextDocument: protocol.TextDocumentIdentifier{
			URI: protocol.DocumentURI("file:///test.ts"),
		},
	}
	b, err := json.Marshal(params)
	if err != nil {
		fmt.Println("error:", err)
		return
	}
	fmt.Println(string(b))
}

```

</details> 

Output on `main` (96af6d2cb5f60035d7a8651ffbb14a94c685a061):
```json
{"textDocument":{"uri":"file:///test.ts"},"workDoneToken":null}
```

Output with PR:
```json
{"textDocument":{"uri":"file:///test.ts"}}
```

I've not validated it by building `crush` from source and `replace`-ing `powernap` with the PR.