### PR TITLE
fix(vt): send SS3 for Home and End under DECCKM

### DIFF
--- a/vt/key.go
+++ b/vt/key.go
@@ -151,9 +151,17 @@ func (e *Emulator) SendKey(k uv.KeyEvent) {
 		case KeyPressEvent{Code: KeyDelete}:
 			seq += "\x1b[3~"
 		case KeyPressEvent{Code: KeyHome}:
-			seq += "\x1b[H"
+			if ack {
+				seq += "\x1bOH"
+			} else {
+				seq += "\x1b[H"
+			}
 		case KeyPressEvent{Code: KeyEnd}:
-			seq += "\x1b[F"
+			if ack {
+				seq += "\x1bOF"
+			} else {
+				seq += "\x1b[F"
+			}
 		case KeyPressEvent{Code: KeyPgUp}:
 			seq += "\x1b[5~"
 		case KeyPressEvent{Code: KeyPgDown}:

--- a/vt/key_test.go
+++ b/vt/key_test.go
@@ -1,0 +1,64 @@
+package vt
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// sendKey writes into the emulator's pipe, which blocks until a reader
+// arrives, so the read has to be waiting first.
+func sendKey(t *testing.T, e *Emulator, k uv.KeyEvent) string {
+	t.Helper()
+	out := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 32)
+		n, err := e.Read(buf)
+		if err != nil && err != io.EOF {
+			out <- ""
+			return
+		}
+		out <- string(buf[:n])
+	}()
+	go e.SendKey(k)
+	select {
+	case s := <-out:
+		return s
+	case <-time.After(time.Second):
+		t.Fatal("SendKey wrote nothing within a second")
+		return ""
+	}
+}
+
+// Home and End follow DECCKM, like the arrow keys beside them. terminfo
+// pairs smkx (\E[?1h, which is DECCKM) with khome=\EOH and kend=\EOF, so
+// an ncurses application that called keypad(true) matches incoming bytes
+// against the SS3 forms and never recognizes the CSI ones.
+func TestSendKeyCursorKeysFollowDECCKM(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		key              uv.KeyPressEvent
+		normal, applicat string
+	}{
+		{"up", uv.KeyPressEvent{Code: KeyUp}, "\x1b[A", "\x1bOA"},
+		{"down", uv.KeyPressEvent{Code: KeyDown}, "\x1b[B", "\x1bOB"},
+		{"right", uv.KeyPressEvent{Code: KeyRight}, "\x1b[C", "\x1bOC"},
+		{"left", uv.KeyPressEvent{Code: KeyLeft}, "\x1b[D", "\x1bOD"},
+		{"home", uv.KeyPressEvent{Code: KeyHome}, "\x1b[H", "\x1bOH"},
+		{"end", uv.KeyPressEvent{Code: KeyEnd}, "\x1b[F", "\x1bOF"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewEmulator(80, 24)
+			if got := sendKey(t, e, tc.key); got != tc.normal {
+				t.Errorf("DECCKM reset: got %q, want %q", got, tc.normal)
+			}
+			e2 := NewEmulator(80, 24)
+			e2.WriteString("\x1b[?1h")
+			if got := sendKey(t, e2, tc.key); got != tc.applicat {
+				t.Errorf("DECCKM set: got %q, want %q", got, tc.applicat)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`SendKey` computes `ack` from `ansi.ModeCursorKeys` and uses it to pick SS3 or CSI for the four arrow keys ([`vt/key.go` L124-147](https://github.com/charmbracelet/x/blob/96af6d2/vt/key.go#L124-L147)), but `KeyHome` and `KeyEnd` twenty lines below emit CSI unconditionally ([L153-156](https://github.com/charmbracelet/x/blob/96af6d2/vt/key.go#L153-L156)). Under DECCKM they should be `ESC O H` and `ESC O F`.

Those are the forms this stack already recognizes on the way in. `ultraviolet`'s key table lists them under its own `// Application Cursor Key Mode (DECCKM)` heading, right beside `ESC O A`..`ESC O D`:

```go
// Application Cursor Key Mode (DECCKM)
"\x1bOA": {Code: KeyUp},
...
"\x1bOF": {Code: KeyEnd},
"\x1bOH": {Code: KeyHome},
```

So an `Emulator` whose output is decoded by `ultraviolet` round-trips the arrows and drops Home and End. `terminfo` says the same thing from the other side — `xterm-256color` pairs `smkx=\E[?1h` (which is DECCKM) with `khome=\EOH` and `kend=\EOF`, so an ncurses application that called `keypad(true)` compares against the SS3 forms and never matches the CSI ones.

## How this has been tested

`vt/key_test.go` (new) covers all six cursor keys in both modes, so the four arrows document the behaviour Home and End now match.

A/B on this branch, against its parent `96af6d2`:

- parent + the new test: two failures, and only those two —
  ```
  --- FAIL: TestSendKeyCursorKeysFollowDECCKM/home
      key_test.go:60: DECCKM set: got "\x1b[H", want "\x1bOH"
  --- FAIL: TestSendKeyCursorKeysFollowDECCKM/end
      key_test.go:60: DECCKM set: got "\x1b[F", want "\x1bOF"
  ```
- with the fix: `go test -race ./...` green in `vt/`, repeated 5×; `gofmt -l` empty; `go build ./...` clean.

Bounds, honestly: this was run on darwin/arm64 with Go 1.26 only. I did not exercise it against a real ncurses application — the terminfo entry above is the evidence for that claim, not a live run.

## Two things a reviewer will notice

**The test starts goroutines.** `SendKey` writes into the emulator's `io.Pipe`, which blocks until something reads, so the read has to be waiting before the send. That is the same blocking #953 is addressing; if that lands first, the helper simplifies and I am happy to follow up.

**Modified cursor keys are a separate defect and not in this PR.** `KeyPressEvent{Code: KeyUp, Mod: ModCtrl}` matches no case and falls to `default:`, where `if key.Mod == 0` means nothing is written at all — the keystroke disappears. xterm sends `ESC [ 1 ; 5 A`. I have kept it out to keep this PR single-purpose, and I want to flag that this is a different axis from the `// TODO: Support Kitty, CSI u, and XTerm modifyOtherKeys` at the top of the function: `CSI 1 ; m A` is plain xterm cursor-key modifier encoding, not modifyOtherKeys and not the Kitty protocol. Happy to open an issue or a follow-up PR, whichever you prefer.
