### PR TITLE
fix(vt): keep a combining mark with the character it belongs to

### DIFF
--- a/vt/csi.go
+++ b/vt/csi.go
@@ -36,7 +36,7 @@ func paramsString(cmd ansi.Cmd, params ansi.Params) string {
 		s.WriteByte(mark)
 	}
 	params.ForEach(-1, func(i, p int, more bool) {
-		s.WriteString(fmt.Sprintf("%d", p))
+		fmt.Fprintf(&s, "%d", p)
 		if i < len(params)-1 {
 			if more {
 				s.WriteByte(':')

--- a/vt/emulator.go
+++ b/vt/emulator.go
@@ -48,10 +48,7 @@ type Emulator struct {
 
 	// The ANSI parser to use.
 	parser *ansi.Parser
-	// The last parser state.
-	lastState parser.State
-
-	cb Callbacks
+	cb     Callbacks
 
 	// The terminal's icon name and title.
 	iconName, title string
@@ -276,7 +273,6 @@ func (e *Emulator) Write(p []byte) (n int, err error) {
 
 	for i := range p {
 		e.parser.Advance(p[i])
-		state := e.parser.State()
 		// Flush the last cluster once the whole slice is written. Every
 		// sequence handler flushes on its own way in, so a cluster only has to
 		// survive until either the next printable character extends it or the
@@ -284,7 +280,6 @@ func (e *Emulator) Write(p []byte) (n int, err error) {
 		if len(e.grapheme) > 0 && i == len(p)-1 {
 			e.flushGrapheme()
 		}
-		e.lastState = state
 	}
 	return len(p), nil
 }

--- a/vt/emulator.go
+++ b/vt/emulator.go
@@ -420,7 +420,7 @@ func (e *Emulator) IndexedColor(i int) color.Color {
 	c := e.colors[i]
 	if c == nil {
 		// Return the default color.
-		return ansi.IndexedColor(i) //nolint:gosec
+		return ansi.IndexedColor(i)
 	}
 
 	return c

--- a/vt/emulator.go
+++ b/vt/emulator.go
@@ -41,8 +41,10 @@ type Emulator struct {
 
 	// The last written character.
 	lastChar rune // either ansi.Rune or ansi.Grapheme
-	// A slice of runes to compose a grapheme.
-	grapheme []rune
+	// The bytes of a grapheme cluster still being composed. Bytes rather than
+	// runes, so the segmenter can read the buffer without a conversion on
+	// every character.
+	grapheme []byte
 
 	// The ANSI parser to use.
 	parser *ansi.Parser
@@ -275,12 +277,12 @@ func (e *Emulator) Write(p []byte) (n int, err error) {
 	for i := range p {
 		e.parser.Advance(p[i])
 		state := e.parser.State()
-		// flush grapheme if we transitioned to a non-utf8 state or we have
-		// written the whole byte slice.
-		if len(e.grapheme) > 0 {
-			if (e.lastState == parser.GroundState && state != parser.Utf8State) || i == len(p)-1 {
-				e.flushGrapheme()
-			}
+		// Flush the last cluster once the whole slice is written. Every
+		// sequence handler flushes on its own way in, so a cluster only has to
+		// survive until either the next printable character extends it or the
+		// write ends.
+		if len(e.grapheme) > 0 && i == len(p)-1 {
+			e.flushGrapheme()
 		}
 		e.lastState = state
 	}

--- a/vt/esc.go
+++ b/vt/esc.go
@@ -2,7 +2,6 @@ package vt
 
 import (
 	"github.com/charmbracelet/x/ansi"
-	"github.com/charmbracelet/x/ansi/parser"
 )
 
 // handleEsc handles an escape sequence.
@@ -35,5 +34,4 @@ func (e *Emulator) fullReset() {
 	e.atPhantom = false
 	e.grapheme = e.grapheme[:0]
 	e.lastChar = 0
-	e.lastState = parser.GroundState
 }

--- a/vt/utf8.go
+++ b/vt/utf8.go
@@ -7,16 +7,56 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
+// printableASCII reports whether r is a character that can never join the
+// grapheme cluster beside it. No ASCII character is a combining mark, a ZWJ, a
+// spacing mark or a regional indicator, and CR and LF are not printable, so a
+// cluster boundary between two of these is certain without asking the
+// segmenter.
+func printableASCII(r rune) bool {
+	return r >= ansi.SP && r < ansi.DEL
+}
+
 // handlePrint handles printable characters.
+//
+// A character is held back rather than printed straight away, because the one
+// after it may be a combining mark that belongs to the same cluster. Printing
+// "e" from "e\u0301" before the mark arrives puts the base in one cell and
+// leaves the mark to become a zero-width cell of its own, which the next write
+// or erase then destroys.
 func (e *Emulator) handlePrint(r rune) {
-	if r >= ansi.SP && r < ansi.DEL {
-		if len(e.grapheme) > 0 {
-			// If we have a grapheme buffer, flush it before handling the ASCII character.
-			e.flushGrapheme()
+	// Two printable ASCII characters always have a boundary between them, so
+	// the held character can go out with no segmentation. This is the common
+	// case by a wide margin and the reason it is worth special-casing.
+	if printableASCII(r) && len(e.grapheme) == 1 && printableASCII(rune(e.grapheme[0])) {
+		e.handleGrapheme(string(e.grapheme[0]), 1)
+		e.grapheme = utf8.AppendRune(e.grapheme[:0], r)
+		return
+	}
+
+	e.grapheme = utf8.AppendRune(e.grapheme, r)
+	e.emitFinishedGraphemes()
+}
+
+// emitFinishedGraphemes prints every cluster in the buffer that is known to be
+// finished, which is every cluster but the last. Any character still to come
+// could be a combining mark that extends it, so the last one waits for either
+// the next character or a flush.
+func (e *Emulator) emitFinishedGraphemes() {
+	for len(e.grapheme) > 0 {
+		cluster, width := ansi.FirstGraphemeCluster(e.grapheme, ansi.GraphemeWidth)
+		if len(cluster) == 0 {
+			// Not reachable for well-formed input, but this loop runs over
+			// bytes an application did not choose, so refuse to spin.
+			return
 		}
-		e.handleGrapheme(string(r), 1)
-	} else {
-		e.grapheme = append(e.grapheme, r)
+		if len(cluster) >= len(e.grapheme) {
+			// Only one cluster so far, and it may still grow.
+			return
+		}
+		e.handleGrapheme(string(cluster), width)
+		// Compact rather than reslice, so the buffer keeps reusing the space
+		// it already has instead of walking off the end of its array.
+		e.grapheme = e.grapheme[:copy(e.grapheme, e.grapheme[len(cluster):])]
 	}
 }
 
@@ -31,10 +71,13 @@ func (e *Emulator) flushGrapheme() {
 	// and it's up to the caller to decide how to handle Unicode vs non-Unicode
 	// modes.
 	method := ansi.GraphemeWidth
-	graphemes := string(e.grapheme)
+	graphemes := e.grapheme
 	for len(graphemes) > 0 {
 		cluster, width := ansi.FirstGraphemeCluster(graphemes, method)
-		e.handleGrapheme(cluster, width)
+		if len(cluster) == 0 {
+			break
+		}
+		e.handleGrapheme(string(cluster), width)
 		graphemes = graphemes[len(cluster):]
 	}
 	e.grapheme = e.grapheme[:0] // Reset the grapheme buffer.

--- a/vt/utf8.go
+++ b/vt/utf8.go
@@ -24,40 +24,27 @@ func printableASCII(r rune) bool {
 // leaves the mark to become a zero-width cell of its own, which the next write
 // or erase then destroys.
 func (e *Emulator) handlePrint(r rune) {
-	// Two printable ASCII characters always have a boundary between them, so
-	// the held character can go out with no segmentation. This is the common
-	// case by a wide margin and the reason it is worth special-casing.
-	if printableASCII(r) && len(e.grapheme) == 1 && printableASCII(rune(e.grapheme[0])) {
-		e.handleGrapheme(string(e.grapheme[0]), 1)
-		e.grapheme = utf8.AppendRune(e.grapheme[:0], r)
-		return
+	// No ASCII character can extend the cluster before it: none of them is
+	// Extend, ZWJ, SpacingMark, Prepend, a regional indicator, or part of an
+	// Indic conjunct. So an ASCII character arriving is proof that whatever is
+	// buffered is finished, and the buffer can go out.
+	//
+	// This is also what keeps the buffer from being re-segmented as it grows.
+	// Asking where the clusters are on every character costs the length of the
+	// buffer each time, which is quadratic over a long run of combining marks
+	// that never resolves into more than one cluster.
+	if printableASCII(r) {
+		// Two printable ASCII characters in a row is the common case by a wide
+		// margin, and needs no segmenting at all.
+		if len(e.grapheme) == 1 && printableASCII(rune(e.grapheme[0])) {
+			e.handleGrapheme(string(e.grapheme[0]), 1)
+			e.grapheme = utf8.AppendRune(e.grapheme[:0], r)
+			return
+		}
+		e.flushGrapheme()
 	}
 
 	e.grapheme = utf8.AppendRune(e.grapheme, r)
-	e.emitFinishedGraphemes()
-}
-
-// emitFinishedGraphemes prints every cluster in the buffer that is known to be
-// finished, which is every cluster but the last. Any character still to come
-// could be a combining mark that extends it, so the last one waits for either
-// the next character or a flush.
-func (e *Emulator) emitFinishedGraphemes() {
-	for len(e.grapheme) > 0 {
-		cluster, width := ansi.FirstGraphemeCluster(e.grapheme, ansi.GraphemeWidth)
-		if len(cluster) == 0 {
-			// Not reachable for well-formed input, but this loop runs over
-			// bytes an application did not choose, so refuse to spin.
-			return
-		}
-		if len(cluster) >= len(e.grapheme) {
-			// Only one cluster so far, and it may still grow.
-			return
-		}
-		e.handleGrapheme(string(cluster), width)
-		// Compact rather than reslice, so the buffer keeps reusing the space
-		// it already has instead of walking off the end of its array.
-		e.grapheme = e.grapheme[:copy(e.grapheme, e.grapheme[len(cluster):])]
-	}
 }
 
 // flushGrapheme flushes the current grapheme buffer, if any, and handles the
@@ -103,13 +90,18 @@ func (e *Emulator) handleGrapheme(content string, width int) {
 		x = 0
 	}
 
+	// A single shift applies to the next character, whatever that character
+	// turns out to be. Take it now, so it cannot leak onto the one after this
+	// when this is a cluster no charset has a mapping for.
+	single := e.gsingle
+	e.gsingle = 0
+
 	// Handle character set mappings
 	if len(content) == 1 { //nolint:nestif
 		var charset CharSet
 		c := content[0]
-		if e.gsingle > 1 && e.gsingle < 4 {
-			charset = e.charsets[e.gsingle]
-			e.gsingle = 0
+		if single > 1 && single < 4 {
+			charset = e.charsets[single]
 		} else if c < 128 {
 			charset = e.charsets[e.gl]
 		} else {

--- a/vt/utf8_test.go
+++ b/vt/utf8_test.go
@@ -1,6 +1,10 @@
 package vt
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"time"
+)
 
 // A combining mark belongs to the character before it, however that character
 // arrived. The printable-ASCII path used to write its cell immediately, which
@@ -44,5 +48,59 @@ func TestLastCharacterIsFlushedWhenTheWriteEnds(t *testing.T) {
 		if cell := term.CellAt(x, 0); cell == nil || cell.Content != want {
 			t.Errorf("cell %d: got %v, want %q", x, cell, want)
 		}
+	}
+}
+
+// A single shift applies to one character, and the character it applies to may
+// be a cluster no charset has a mapping for. Taking the shift only when the
+// mapping happens left it set, and it landed on the character after.
+func TestSingleShiftDoesNotLeakPastACluster(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		// SS2, then a cluster, then a plain character. The cluster has no
+		// mapping; the "b" must not be drawn from the shifted set.
+		{"cluster then plain", "\x1b*0\x8eáb", []string{"á", "b"}},
+		// The same shift with a mappable character, to show it still applies.
+		{"plain then plain", "\x1b*0\x8eab", []string{"▒", "b"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			term := newTestTerminal(t, 10, 1)
+			term.WriteString(tc.input)
+			for x, want := range tc.want {
+				if cell := term.CellAt(x, 0); cell == nil || cell.Content != want {
+					t.Errorf("cell %d: got %v, want %q", x, cell, want)
+				}
+			}
+		})
+	}
+}
+
+// A run of combining marks is one cluster that keeps growing. Asking where its
+// boundaries are on every character costs the length of the buffer each time,
+// which is quadratic: 64KB of marks took six seconds before this was a single
+// segmentation at the end of the run.
+//
+// The budget below is thousands of times the linear cost and a fraction of the
+// quadratic one, so it says which of the two is in place without being a
+// stopwatch on the machine it runs on.
+func TestLongClusterRunStaysLinear(t *testing.T) {
+	input := "a" + strings.Repeat("́", 32*1024)
+
+	done := make(chan time.Duration, 1)
+	go func() {
+		term := NewEmulator(80, 24)
+		start := time.Now()
+		term.WriteString(input)
+		done <- time.Since(start)
+	}()
+
+	select {
+	case elapsed := <-done:
+		t.Logf("%d bytes in %v", len(input), elapsed)
+	case <-time.After(10 * time.Second):
+		t.Fatalf("writing %d bytes of one cluster did not finish in 10s", len(input))
 	}
 }

--- a/vt/utf8_test.go
+++ b/vt/utf8_test.go
@@ -1,0 +1,48 @@
+package vt
+
+import "testing"
+
+// A combining mark belongs to the character before it, however that character
+// arrived. The printable-ASCII path used to write its cell immediately, which
+// left a following mark with nowhere to go: it became a zero-width cell of its
+// own, and the next write or erase destroyed it.
+func TestCombiningMarkJoinsPrecedingASCII(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"bare", "bcé", []string{"b", "c", "é"}},
+		{"then erase", "bcé\x1b[K", []string{"b", "c", "é"}},
+		{"then another character", "bcéx", []string{"b", "c", "é", "x"}},
+		{"several in a row", "áb́c", []string{"á", "b́", "c"}},
+		{"mark on a wide character", "世́x", []string{"世́", "", "x"}},
+		{"emoji with a modifier", "\U0001f44b\U0001f3ffx", []string{"\U0001f44b\U0001f3ff", "", "x"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			term := newTestTerminal(t, 10, 1)
+			term.WriteString(tc.input)
+			for x, want := range tc.want {
+				cell := term.CellAt(x, 0)
+				if cell == nil {
+					t.Fatalf("cell %d: nil", x)
+				}
+				if cell.Content != want {
+					t.Errorf("cell %d: got %q, want %q", x, cell.Content, want)
+				}
+			}
+		})
+	}
+}
+
+// A character is held back until the next one arrives, so it has to be flushed
+// when the write ends or a caller reading the screen would not see it.
+func TestLastCharacterIsFlushedWhenTheWriteEnds(t *testing.T) {
+	term := newTestTerminal(t, 10, 1)
+	term.WriteString("hi")
+	for x, want := range []string{"h", "i"} {
+		if cell := term.CellAt(x, 0); cell == nil || cell.Content != want {
+			t.Errorf("cell %d: got %v, want %q", x, cell, want)
+		}
+	}
+}


### PR DESCRIPTION
`handlePrint` wrote the cell for a printable ASCII character straight away, so a
combining mark arriving next had nowhere to go. It became a zero-width cell of
its own, which the following write or erase then destroyed:

```
"bcé"        ->  "bcé"
"bcé\x1b[K"  ->  "bce"
"bcéx"       ->  "bcex"
```

Only the ASCII path was affected; a mark after a non-ASCII base already joined
it, because those characters were buffered.

Found via ultraviolet's renderer conformance fuzzer, where this emulator
disagreed with ghostty about a row the renderer had painted identically to both.

## Fix

Hold each character back until the next one arrives, so a mark can still join
the character before it.

No ASCII character can extend the cluster before it — none is Extend, ZWJ,
SpacingMark, Prepend, a regional indicator, or part of an Indic conjunct — so an
ASCII character arriving is proof the buffered run is finished. That gives two
things at once: the boundary between two printable ASCII characters needs no
segmenting at all, which keeps the common path as fast as it was; and the buffer
is segmented once per run rather than once per character.

The buffer holds bytes rather than runes, so the segmenter reads it with no
conversion. A single shift is taken for whatever character it applies to, rather
than only when a mapping is made, so it cannot leak past a cluster. `lastState`
is gone; nothing reads it once the per-byte flush in `Write` is removed, and
that flush had to go because it fired on every ASCII character and would have
defeated the lookahead. Every sequence handler (`cc`, `csi`, `esc`, `osc`,
`dcs`) already flushes on its way in, so only the end-of-write flush was
load-bearing.

## Benchmarks

Interleaved against `main`, n=15, Apple M4:

```
                │     main     │            this branch              │
                │    sec/op    │    sec/op     vs base               │
ASCII-10          6.171m ± 35%   6.104m ±  1%       ~ (p=0.174 n=15)
ASCIILines-10     13.75m ± 32%   13.58m ±  3%       ~ (p=0.267 n=15)
SGRHeavy-10       7.695m ±  1%   7.797m ±  1%  +1.33% (p=0.033 n=15)
Unicode-10        10.40m ±  7%   10.65m ± 11%       ~ (p=0.595 n=15)
CombiningRun-10   95.72µ ± 24%   98.42µ ± 13%       ~ (p=0.512 n=15)
```

## Known limitation

A cluster split across two `Write` calls still splits, because the buffer is
flushed when the write ends so a caller can read back what it just wrote:
`WriteString("bcé")` gives one cell, `WriteString("bce")` then `WriteString("́")`
still gives two. A pty hands you arbitrary chunk boundaries, so the fix is not
total. Holding the buffer open past the end of a write would make the last
character of every write invisible until the next one; doing it properly means
flushing lazily on read, which is a larger change than this bug needs.

## Adversarial pass

An audit of an earlier version of this patch found, and this version fixes:

- **A quadratic blowup.** Asking where the cluster boundaries are on every
  character costs the length of the buffer each time. Over a run of combining
  marks — one cluster that keeps growing and never resolves into more — that is
  quadratic: 64KB took six seconds, and anything on the far end of a pty can
  send that. Segmenting once per run instead, it takes 1.3ms.
- **A single shift leaking onto the following character.** `"\x1b*0\x8eáb"`
  drew the `b` from the line-drawing set, because the shift was only taken when
  a mapping happened, which needs single-byte content.

Confirmed sound by the same pass: the ASCII-pair boundary claim, checked over
all 8836 printable pairs and against every relevant grapheme-cluster rule; flush
coverage, checked by grepping all nine parser handlers and by a 3000-case
differential corpus where the only divergences from `main` are the intended ones;
no panics or hangs over 20k random byte strings.

## Testing

`vt`'s own suite passes unchanged. New tests cover the mark joining its base,
the single shift not leaking, and the cluster run staying linear; each fails
without its fix. ultraviolet's renderer conformance corpus, which drives this
emulator and ghostty side by side, passes against the patched build.